### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -21,7 +21,7 @@ jobs:
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.1.0
+      uses: gradle/actions/setup-gradle@v4.2.0
 
     - name: Install libcurl4
       run: sudo apt-get install -y libcurl4-gnutls-dev

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -17,7 +17,7 @@ jobs:
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.1.0
+      uses: gradle/actions/setup-gradle@v4.2.0
 
     - name: Install libcurl4
       run: sudo apt-get install -y libcurl4-gnutls-dev

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,7 +28,7 @@ jobs:
         java-version: 22
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.1.0
+      uses: gradle/actions/setup-gradle@v4.2.0
 
     - name: Install libcurl4
       run: sudo apt-get install -y libcurl4-gnutls-dev


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v4.2.0](https://github.com/gradle/actions/releases/tag/v4.2.0)** on 2024-11-12T17:24:57Z
