### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -54,7 +54,7 @@ jobs:
       run: sh .github/scripts/update-readme-version.sh
 
     - name: Commit README
-      uses: stefanzweifel/git-auto-commit-action@v5.0.1
+      uses: stefanzweifel/git-auto-commit-action@v5.1.0
       with:
         commit_message: Dependency version in README.md updated to ${{ env.VERSION }}
         file_pattern: 'README.md'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action)** published a new release **[v5.1.0](https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v5.1.0)** on 2025-01-11T07:12:05Z
