### PR TITLE
Add support for unknown models and update API specifications

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ ktor = "3.2.2"
 kotest = "6.0.0.M5"
 
 xemanticKotlinCore = "0.2.0"
-xemanticKotlinTest = "1.9.0"
+xemanticKotlinTest = "1.13.0"
 xemanticAiToolSchema = "1.1.2"
 xemanticAiMoney = "0.2"
 xemanticAiFileMagic = "0.3.1"
@@ -21,7 +21,7 @@ jackson = "2.19.2"
 versionsPlugin = "0.52.0"
 dokkaPlugin = "2.0.0"
 jreleaserPlugin = "1.19.0"
-xemanticConventionsPlugin = "0.3.3"
+xemanticConventionsPlugin = "0.4.3"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/src/commonMain/kotlin/Anthropic.kt
+++ b/src/commonMain/kotlin/Anthropic.kt
@@ -117,7 +117,8 @@ class Anthropic internal constructor(
         var directBrowserAccess: Boolean = false
         var logHttp: Boolean = false
 
-        var modelMap: Map<String, AnthropicModel> = Model.entries.associateBy { it.id }
+        var modelMap: MutableMap<String, AnthropicModel> =
+            Model.entries.associateBy { it.id }.toMutableMap()
 
         operator fun Beta.unaryPlus() {
             anthropicBeta += this.id
@@ -296,7 +297,7 @@ class Anthropic internal constructor(
         get() = requireNotNull(
             modelMap[model]
         ) {
-            "The model returned in the response is not known to Anthropic API client: $id"
+            "Unknown model '$model', consider adding modelMap[\"$model\"] = UnknownModel(...) when creating Anthropic client instance."
         }
 
     override fun toString(): String = "Anthropic($costWithUsage)"

--- a/src/commonMain/kotlin/Models.kt
+++ b/src/commonMain/kotlin/Models.kt
@@ -31,6 +31,7 @@ interface AnthropicModel {
     val maxOutput: Int
     val messageBatchesApi: Boolean
     val cost: Cost
+    val deprecated: Boolean
 
 }
 
@@ -43,39 +44,17 @@ val String.dollarsPerMillion: Money get() = Money(this) * ANTHROPIC_TOKEN_COST_R
  *
  * It could include Vertex AI (Google Cloud), or Bedrock (AWS) models in the future.
  */
-// TODO model should be interface AnthropicApi models should be enum
 enum class Model(
     override val id: String,
     override val contextWindow: Int,
     override val maxOutput: Int,
     override val messageBatchesApi: Boolean,
-    override val cost: Cost
+    override val cost: Cost,
+    override val deprecated: Boolean = false
 ) : AnthropicModel {
 
-    CLAUDE_4_OPUS(
-        id = "claude-opus-4-0",
-        contextWindow = 200000,
-        maxOutput = 32000,
-        messageBatchesApi = true,
-        cost = Cost {
-            inputTokens = "15".dollarsPerMillion
-            outputTokens = "75".dollarsPerMillion
-        }
-    ),
-
-    CLAUDE_4_OPUS_20250514(
-        id = "claude-opus-4-20250514",
-        contextWindow = 200000,
-        maxOutput = 32000,
-        messageBatchesApi = true,
-        cost = Cost {
-            inputTokens = "15".dollarsPerMillion
-            outputTokens = "75".dollarsPerMillion
-        }
-    ),
-
-    CLAUDE_4_SONNET(
-        id = "claude-sonnet-4-0",
+    CLAUDE_SONNET_4_5_20250929(
+        id = "claude-sonnet-4-5-20250929",
         contextWindow = 200000,
         maxOutput = 64000,
         messageBatchesApi = true,
@@ -85,19 +64,19 @@ enum class Model(
         }
     ),
 
-    CLAUDE_4_SONNET_20250514(
+    CLAUDE_OPUS_4_1_20250805(
+        id = "claude-opus-4-1-20250805",
+        contextWindow = 200000,
+        maxOutput = 32000,
+        messageBatchesApi = true,
+        cost = Cost {
+            inputTokens = "15".dollarsPerMillion
+            outputTokens = "75".dollarsPerMillion
+        }
+    ),
+
+    CLAUDE_SONNET_4_20250514(
         id = "claude-sonnet-4-20250514",
-        contextWindow = 200000,
-        maxOutput = 64000,
-        messageBatchesApi = true,
-        cost = Cost {
-            inputTokens = "3".dollarsPerMillion
-            outputTokens = "15".dollarsPerMillion
-        }
-    ),
-
-    CLAUDE_3_7_SONNET(
-        id = "claude-3-7-sonnet-latest",
         contextWindow = 200000,
         maxOutput = 64000,
         messageBatchesApi = true,
@@ -118,70 +97,38 @@ enum class Model(
         }
     ),
 
-    CLAUDE_3_5_SONNET(
-        id = "claude-3-5-sonnet-latest",
+    CLAUDE_3_5_HAIKU_20241022(
+        id = "claude-3-5-haiku-20241022",
         contextWindow = 200000,
-        maxOutput = 8182,
+        maxOutput = 8192,
         messageBatchesApi = true,
         cost = Cost {
-            inputTokens = "3".dollarsPerMillion
-            outputTokens = "15".dollarsPerMillion
+            inputTokens = "0.80".dollarsPerMillion
+            outputTokens = "4".dollarsPerMillion
         }
     ),
 
     CLAUDE_3_5_SONNET_20241022(
         id = "claude-3-5-sonnet-20241022",
         contextWindow = 200000,
-        maxOutput = 8182,
+        maxOutput = 8192,
         messageBatchesApi = true,
         cost = Cost {
             inputTokens = "3".dollarsPerMillion
             outputTokens = "15".dollarsPerMillion
-        }
-    ),
-
-    CLAUDE_3_5_HAIKU(
-        id = "claude-3-5-haiku-latest",
-        contextWindow = 200000,
-        maxOutput = 8182,
-        messageBatchesApi = true,
-        cost = Cost {
-            inputTokens = "0.80".dollarsPerMillion
-            outputTokens = "4".dollarsPerMillion
-        }
-    ),
-
-    CLAUDE_3_5_HAIKU_20241022(
-        id = "claude-3-5-haiku-20241022",
-        contextWindow = 200000,
-        maxOutput = 8182,
-        messageBatchesApi = true,
-        cost = Cost {
-            inputTokens = "0.80".dollarsPerMillion
-            outputTokens = "4".dollarsPerMillion
         }
     ),
 
     CLAUDE_3_5_SONNET_20240620(
         id = "claude-3-5-sonnet-20240620",
         contextWindow = 200000,
-        maxOutput = 8182,
+        maxOutput = 8192,
         messageBatchesApi = true,
         cost = Cost {
             inputTokens = "3".dollarsPerMillion
             outputTokens = "15".dollarsPerMillion
-        }
-    ),
-
-    CLAUDE_3_OPUS(
-        id = "claude-3-opus-latest",
-        contextWindow = 200000,
-        maxOutput = 4096,
-        messageBatchesApi = true,
-        cost = Cost {
-            inputTokens = "15".dollarsPerMillion
-            outputTokens = "75".dollarsPerMillion
-        }
+        },
+        deprecated = true
     ),
 
     CLAUDE_3_OPUS_20240229(
@@ -192,18 +139,8 @@ enum class Model(
         cost = Cost {
             inputTokens = "15".dollarsPerMillion
             outputTokens = "75".dollarsPerMillion
-        }
-    ),
-
-    CLAUDE_3_SONNET_20240229(
-        id = "claude-3-sonnet-20240229",
-        contextWindow = 200000,
-        maxOutput = 4096,
-        messageBatchesApi = true,
-        cost = Cost {
-            inputTokens = "3".dollarsPerMillion
-            outputTokens = "15".dollarsPerMillion
-        }
+        },
+        deprecated = true
     ),
 
     CLAUDE_3_HAIKU_20240307(
@@ -219,8 +156,17 @@ enum class Model(
 
     companion object {
 
-        val DEFAULT: Model = CLAUDE_4_SONNET
+        val DEFAULT: Model = CLAUDE_SONNET_4_5_20250929
 
     }
 
 }
+
+data class UnknownModel(
+    override val id: String,
+    override val contextWindow: Int,
+    override val maxOutput: Int,
+    override val messageBatchesApi: Boolean,
+    override val cost: Cost,
+    override val deprecated: Boolean = false
+) : AnthropicModel

--- a/src/commonMain/kotlin/cost/CostReporting.kt
+++ b/src/commonMain/kotlin/cost/CostReporting.kt
@@ -36,11 +36,18 @@ fun costReport(
         "$${totalStats.cost.outputTokens}",
     )
     row(
-        "cache write",
-        stats.usage.cacheCreationInputTokens ?: 0,
-        totalStats.usage.cacheCreationInputTokens ?: 0,
-        "$${stats.cost.cacheCreationInputTokens}",
-        "$${totalStats.cost.cacheCreationInputTokens}"
+        "cache 5m write",
+        stats.usage.cacheCreation?.ephemeral5mInputTokens ?: 0,
+        totalStats.usage.cacheCreation?.ephemeral5mInputTokens ?: 0,
+        "$${stats.cost.cache5mCreationInputTokens}",
+        "$${totalStats.cost.cache5mCreationInputTokens}"
+    )
+    row(
+        "cache 1h write",
+        stats.usage.cacheCreation?.ephemeral1hInputTokens ?: 0,
+        totalStats.usage.cacheCreation?.ephemeral1hInputTokens ?: 0,
+        "$${stats.cost.cache1hCreationInputTokens}",
+        "$${totalStats.cost.cache1hCreationInputTokens}"
     )
     row(
         "cache read",

--- a/src/commonMain/kotlin/json/AnthropicJson.kt
+++ b/src/commonMain/kotlin/json/AnthropicJson.kt
@@ -159,7 +159,7 @@ object ToolSerializer : KSerializer<Tool> {
         } else {
             when (val name = tree.stringProperty("name")) {
                 "computer" -> Computer.serializer()
-                "str_replace_editor" -> TextEditor.serializer()
+                "str_replace_based_edit_tool" -> TextEditor.serializer()
                 "bash" -> Bash.serializer()
                 else -> throw SerializationException("Unsupported Tool name: $name")
             }

--- a/src/commonMain/kotlin/tool/TextEditor.kt
+++ b/src/commonMain/kotlin/tool/TextEditor.kt
@@ -20,10 +20,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-@SerialName("str_replace_editor")
-class TextEditor private constructor() : BuiltInTool<TextEditor.Input>(
-    name = "str_replace_editor",
-    type = "text_editor_20250124"
+@SerialName("str_replace_based_edit_tool")
+class TextEditor private constructor(
+    @SerialName("max_characters")
+    val maxCharacters: Int? = null
+) : BuiltInTool<TextEditor.Input>(
+    name = "str_replace_based_edit_tool",
+    type = "text_editor_20250728"
 ) {
 
     @Suppress("unused")
@@ -39,10 +42,7 @@ class TextEditor private constructor() : BuiltInTool<TextEditor.Input>(
         STR_REPLACE,
 
         @SerialName("insert")
-        INSERT,
-
-        @SerialName("undo_edit")
-        UNDO_EDIT
+        INSERT
     }
 
     @Serializable
@@ -70,7 +70,7 @@ class TextEditor private constructor() : BuiltInTool<TextEditor.Input>(
             var newStr: String? = null
             var oldStr: String? = null
             var path: String? = null
-            val viewRange: List<Int>? = null
+            var viewRange: List<Int>? = null
 
             fun build(): Input = Input(
                 requireNotNull(command) { "command cannot be null" },
@@ -88,7 +88,11 @@ class TextEditor private constructor() : BuiltInTool<TextEditor.Input>(
 
     class Builder {
 
-        fun build(): TextEditor = TextEditor()
+        var maxCharacters: Int? = null
+
+        fun build(): TextEditor = TextEditor(
+            maxCharacters = maxCharacters
+        )
 
     }
 

--- a/src/commonMain/kotlin/usage/Usage.kt
+++ b/src/commonMain/kotlin/usage/Usage.kt
@@ -24,7 +24,72 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 /**
- * Represents API usage object,
+ * Detailed cache creation token counts broken down by cache duration.
+ */
+@Serializable
+class CacheCreation private constructor(
+    @SerialName("ephemeral_5m_input_tokens")
+    val ephemeral5mInputTokens: Int? = null,
+    @SerialName("ephemeral_1h_input_tokens")
+    val ephemeral1hInputTokens: Int? = null
+) {
+
+    class Builder {
+
+        var ephemeral5mInputTokens: Int? = null
+        var ephemeral1hInputTokens: Int? = null
+
+        fun build(): CacheCreation = CacheCreation(
+            requireNotNull(ephemeral5mInputTokens) { "ephemeral5mInputTokens cannot be null" },
+            requireNotNull(ephemeral1hInputTokens) { "ephemeral1hInputTokens cannot be null"}
+        )
+
+    }
+
+    operator fun plus(cacheCreation: CacheCreation): CacheCreation {
+        return CacheCreation(
+            ephemeral5mInputTokens = (ephemeral5mInputTokens  ?: 0) + (cacheCreation.ephemeral5mInputTokens ?: 0),
+            ephemeral1hInputTokens = (ephemeral1hInputTokens  ?: 0) + (cacheCreation.ephemeral1hInputTokens ?: 0),
+        )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CacheCreation) return false
+
+        if (ephemeral5mInputTokens != other.ephemeral5mInputTokens) return false
+        if (ephemeral1hInputTokens != other.ephemeral1hInputTokens) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = ephemeral5mInputTokens ?: 0
+        result = 31 * result + (ephemeral1hInputTokens ?: 0)
+        return result
+    }
+
+    companion object {
+
+        val ZERO = CacheCreation(
+            ephemeral5mInputTokens = 0,
+            ephemeral1hInputTokens = 0
+        )
+
+    }
+
+}
+
+@OptIn(ExperimentalContracts::class)
+fun CacheCreation(block: CacheCreation.Builder.() -> Unit): CacheCreation {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
+    return CacheCreation.Builder().also(block).build()
+}
+
+/**
+ * Represents API usage object.
  */
 @Serializable
 class Usage private constructor(
@@ -35,7 +100,9 @@ class Usage private constructor(
     @SerialName("cache_creation_input_tokens")
     val cacheCreationInputTokens: Int? = null,
     @SerialName("cache_read_input_tokens")
-    val cacheReadInputTokens: Int? = null
+    val cacheReadInputTokens: Int? = null,
+    @SerialName("cache_creation")
+    val cacheCreation: CacheCreation? = null
 ) {
 
     class Builder {
@@ -44,12 +111,14 @@ class Usage private constructor(
         var outputTokens: Int? = null
         var cacheCreationInputTokens: Int? = null
         var cacheReadInputTokens: Int? = null
+        var cacheCreation: CacheCreation? = null
 
         fun build(): Usage = Usage(
             requireNotNull(inputTokens) { "inputTokens cannot be null" },
             requireNotNull(outputTokens) { "outputTokens cannot be null"},
             cacheCreationInputTokens,
-            cacheReadInputTokens
+            cacheReadInputTokens,
+            cacheCreation
         )
 
     }
@@ -69,19 +138,19 @@ class Usage private constructor(
         inputTokens = inputTokens + usage.inputTokens,
         outputTokens = outputTokens + usage.outputTokens,
         cacheCreationInputTokens = (cacheCreationInputTokens ?: 0) + (usage.cacheCreationInputTokens ?: 0),
-        cacheReadInputTokens = (cacheReadInputTokens ?: 0) + (usage.cacheReadInputTokens ?: 0)
+        cacheReadInputTokens = (cacheReadInputTokens ?: 0) + (usage.cacheReadInputTokens ?: 0),
+        cacheCreation = (cacheCreation ?: CacheCreation.ZERO) + (usage.cacheCreation ?: CacheCreation.ZERO)
     )
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as Usage
+        if (other !is Usage) return false
 
         if (inputTokens != other.inputTokens) return false
         if (outputTokens != other.outputTokens) return false
         if (cacheCreationInputTokens != other.cacheCreationInputTokens) return false
         if (cacheReadInputTokens != other.cacheReadInputTokens) return false
+        if (cacheCreation != other.cacheCreation) return false
 
         return true
     }
@@ -91,6 +160,7 @@ class Usage private constructor(
         result = 31 * result + outputTokens
         result = 31 * result + (cacheCreationInputTokens ?: 0)
         result = 31 * result + (cacheReadInputTokens ?: 0)
+        result = 31 * result + (cacheCreation?.hashCode() ?: 0)
         return result
     }
 

--- a/src/commonTest/kotlin/ResponseStreamingTest.kt
+++ b/src/commonTest/kotlin/ResponseStreamingTest.kt
@@ -122,7 +122,7 @@ class ResponseStreamingTest {
         // then
         exception.error should {
             have(type == "invalid_request_error")
-            have(message == "max_tokens: 1000000000 > 64000, which is the maximum allowed number of output tokens for claude-sonnet-4-20250514")
+            have(message == "max_tokens: 1000000000 > 64000, which is the maximum allowed number of output tokens for claude-sonnet-4-5-20250929")
         }
     }
 

--- a/src/commonTest/kotlin/cost/CostTest.kt
+++ b/src/commonTest/kotlin/cost/CostTest.kt
@@ -29,12 +29,14 @@ class CostTest {
         Cost {
             inputTokens = Money("0.001")
             outputTokens = Money("0.002")
-            cacheCreationInputTokens = Money("0.00025")
+            cache5mCreationInputTokens = Money("0.00025")
+            cache1hCreationInputTokens = Money("0.0003")
             cacheReadInputTokens = Money("0.0005")
         } should {
             have(inputTokens == Money("0.001"))
             have(outputTokens == Money("0.002"))
-            have(cacheCreationInputTokens == Money("0.00025"))
+            have(cache5mCreationInputTokens == Money("0.00025"))
+            have(cache1hCreationInputTokens == Money("0.0003"))
             have(cacheReadInputTokens == Money("0.0005"))
         }
     }
@@ -50,7 +52,8 @@ class CostTest {
         } should {
             have(inputTokens == Money("0.001"))
             have(outputTokens == Money("0.002"))
-            have(cacheCreationInputTokens == Money("0.00125"))
+            have(cache5mCreationInputTokens == Money("0.00125"))
+            have(cache1hCreationInputTokens == Money("0.002"))
             have(cacheReadInputTokens == Money("0.0001"))
         }
     }
@@ -61,13 +64,15 @@ class CostTest {
         val cost1 = Cost {
             inputTokens = Money("0.001")
             outputTokens = Money("0.002")
-            cacheCreationInputTokens = Money.ZERO
+            cache5mCreationInputTokens = Money.ZERO
+            cache1hCreationInputTokens = Money.ZERO
             cacheReadInputTokens = Money.ZERO
         }
         val cost2 = Cost {
             inputTokens = Money("0.003")
             outputTokens = Money("0.004")
-            cacheCreationInputTokens = Money.ZERO
+            cache5mCreationInputTokens = Money.ZERO
+            cache1hCreationInputTokens = Money.ZERO
             cacheReadInputTokens = Money.ZERO
         }
 
@@ -78,7 +83,8 @@ class CostTest {
         result should {
             have(inputTokens == Money("0.004"))
             have(outputTokens == Money("0.006"))
-            have(cacheCreationInputTokens == Money.ZERO)
+            have(cache5mCreationInputTokens == Money.ZERO)
+            have(cache1hCreationInputTokens == Money.ZERO)
             have(cacheReadInputTokens == Money.ZERO)
         }
     }
@@ -89,13 +95,15 @@ class CostTest {
         val cost1 = Cost {
             inputTokens = Money("0.001")
             outputTokens = Money("0.002")
-            cacheCreationInputTokens = Money("0.0001")
+            cache5mCreationInputTokens = Money("0.0001")
+            cache1hCreationInputTokens = Money("0.00015")
             cacheReadInputTokens = Money("0.0002")
         }
         val cost2 = Cost {
             inputTokens = Money("0.003")
             outputTokens = Money("0.004")
-            cacheCreationInputTokens = Money("0.0003")
+            cache5mCreationInputTokens = Money("0.0003")
+            cache1hCreationInputTokens = Money("0.00035")
             cacheReadInputTokens = Money("0.0004")
         }
 
@@ -106,7 +114,8 @@ class CostTest {
         result should {
             have(inputTokens == Money("0.004"))
             have(outputTokens == Money("0.006"))
-            have(cacheCreationInputTokens == Money("0.0004"))
+            have(cache5mCreationInputTokens == Money("0.0004"))
+            have(cache1hCreationInputTokens == Money("0.0005"))
             have(cacheReadInputTokens == Money("0.0006"))
         }
     }
@@ -116,10 +125,11 @@ class CostTest {
         Cost {
             inputTokens = Money("0.001")
             outputTokens = Money("0.002")
-            cacheCreationInputTokens = Money("0.0005")
+            cache5mCreationInputTokens = Money("0.0005")
+            cache1hCreationInputTokens = Money("0.0006")
             cacheReadInputTokens = Money("0.0007")
         } should {
-            have(total == Money("0.0042"))
+            have(total == Money("0.0048"))
         }
     }
 
@@ -128,7 +138,8 @@ class CostTest {
         Cost.ZERO should {
             have(inputTokens == Money.ZERO)
             have(outputTokens == Money.ZERO)
-            have(cacheCreationInputTokens == Money.ZERO)
+            have(cache5mCreationInputTokens == Money.ZERO)
+            have(cache1hCreationInputTokens == Money.ZERO)
             have(cacheReadInputTokens == Money.ZERO)
         }
     }

--- a/src/commonTest/kotlin/message/MessageRequestTest.kt
+++ b/src/commonTest/kotlin/message/MessageRequestTest.kt
@@ -43,7 +43,7 @@ class MessageRequestTest {
         // then
         json shouldEqualJson """
             {
-              "model": "claude-sonnet-4-0",
+              "model": "claude-sonnet-4-5-20250929",
               "messages": [
                 {
                   "role": "user",
@@ -77,7 +77,7 @@ class MessageRequestTest {
         // then
         json shouldEqualJson """
             {
-              "model": "claude-sonnet-4-0",
+              "model": "claude-sonnet-4-5-20250929",
               "messages": [
                 {
                   "role": "user",
@@ -111,7 +111,7 @@ class MessageRequestTest {
         // then
         json shouldEqualJson """
             {
-              "model": "claude-sonnet-4-0",
+              "model": "claude-sonnet-4-5-20250929",
               "messages": [
                 {
                   "role": "user",
@@ -175,7 +175,7 @@ class MessageRequestTest {
         // then
         json shouldEqualJson """
             {
-              "model": "claude-sonnet-4-0",
+              "model": "claude-sonnet-4-5-20250929",
               "messages": [
                 {
                   "role": "user",
@@ -197,8 +197,8 @@ class MessageRequestTest {
                   "display_number": 1
                 },
                 {
-                  "type": "text_editor_20250124",
-                  "name": "str_replace_editor"
+                  "type": "text_editor_20250728",
+                  "name": "str_replace_based_edit_tool"
                 },
                 {
                   "type": "bash_20250124",
@@ -249,7 +249,7 @@ class MessageRequestTest {
         // then
         json shouldEqualJson """
             {
-              "model": "claude-sonnet-4-0",
+              "model": "claude-sonnet-4-5-20250929",
               "messages": [
                 {
                   "role": "user",
@@ -297,7 +297,7 @@ class MessageRequestTest {
         // given
         val request = """
             {
-              "model": "claude-sonnet-4-0",
+              "model": "claude-sonnet-4-5-20250929",
               "messages": [
                 {
                   "role": "user",
@@ -319,8 +319,8 @@ class MessageRequestTest {
                   "display_number": 1
                 },
                 {
-                  "type": "text_editor_20241022",
-                  "name": "str_replace_editor"
+                  "type": "text_editor_20250728",
+                  "name": "str_replace_based_edit_tool"
                 },
                 {
                   "type": "bash_20241022",

--- a/src/commonTest/kotlin/message/MessageResponseUseToolsTest.kt
+++ b/src/commonTest/kotlin/message/MessageResponseUseToolsTest.kt
@@ -57,7 +57,7 @@ class MessageResponseUseToolsTest {
                 }
             }
         ),
-        model = Model.CLAUDE_4_OPUS.id,
+        model = Model.CLAUDE_SONNET_4_5_20250929.id,
         stopReason = StopReason.TOOL_USE,
         stopSequence = null,
         usage = Usage {

--- a/src/commonTest/kotlin/tool/builtin/TextEditorTest.kt
+++ b/src/commonTest/kotlin/tool/builtin/TextEditorTest.kt
@@ -72,8 +72,8 @@ class TextEditorTest {
             TextEditor {}
         ) shouldEqualJson """
             {
-              "name": "str_replace_editor",
-              "type": "text_editor_20250124"
+              "name": "str_replace_based_edit_tool",
+              "type": "text_editor_20250728"
             }
         """
     }
@@ -83,14 +83,14 @@ class TextEditorTest {
         anthropicJson.decodeFromString<Tool>(
             """
            {
-             "name": "str_replace_editor",
-             "type": "text_editor_20250124"
+             "name": "str_replace_based_edit_tool",
+             "type": "text_editor_20250728"
            }
            """
         ) should {
-            have(name == "str_replace_editor")
+            have(name == "str_replace_based_edit_tool")
             be<TextEditor>()
-            have(type == "text_editor_20250124")
+            have(type == "text_editor_20250728")
         }
     }
 
@@ -98,8 +98,8 @@ class TextEditorTest {
     fun `should return JSON for TextEditorTool toString`() {
         TextEditor {}.toString() shouldEqualJson """
             {
-              "name": "str_replace_editor",
-              "type": "text_editor_20250124"
+              "name": "str_replace_based_edit_tool",
+              "type": "text_editor_20250728"
             }
         """
     }

--- a/src/commonTest/kotlin/usage/UsageTest.kt
+++ b/src/commonTest/kotlin/usage/UsageTest.kt
@@ -24,7 +24,23 @@ import kotlin.test.assertFails
 
 class UsageTest {
 
-    // given
+    // given - CacheCreation instances
+    val cacheCreation1 = CacheCreation {
+        ephemeral5mInputTokens = 10
+        ephemeral1hInputTokens = 20
+    }
+
+    val cacheCreation2 = CacheCreation {
+        ephemeral5mInputTokens = 10
+        ephemeral1hInputTokens = 20
+    }
+
+    val cacheCreation3 = CacheCreation {
+        ephemeral5mInputTokens = 30
+        ephemeral1hInputTokens = 40
+    }
+
+    // given - Usage instances
     val usage1 = Usage {
         inputTokens = 1
         outputTokens = 2
@@ -96,6 +112,134 @@ class UsageTest {
         assert(usage1.hashCode() == usage1.hashCode())
         assert(usage1.hashCode() == usage2.hashCode())
         assert(usage1.hashCode() != usage3.hashCode())
+    }
+
+    @Test
+    fun `should add two Usage objects`() {
+        // when
+        val result = usage1 + usage3
+
+        // then
+        result should {
+            have(inputTokens == 6)
+            have(outputTokens == 8)
+            have(cacheCreationInputTokens == 10)
+            have(cacheReadInputTokens == 12)
+        }
+    }
+
+    @Test
+    fun `should add Usage objects with null cache properties`() {
+        // given
+        val usageWithoutCache = Usage {
+            inputTokens = 10
+            outputTokens = 20
+        }
+
+        // when
+        val result = usage1 + usageWithoutCache
+
+        // then
+        result should {
+            have(inputTokens == 11)
+            have(outputTokens == 22)
+            have(cacheCreationInputTokens == 3)
+            have(cacheReadInputTokens == 4)
+        }
+    }
+
+    @Test
+    fun `should add Usage objects with CacheCreation`() {
+        // given
+        val usageWithCache1 = Usage {
+            inputTokens = 100
+            outputTokens = 200
+            cacheCreation = cacheCreation1
+        }
+        val usageWithCache2 = Usage {
+            inputTokens = 300
+            outputTokens = 400
+            cacheCreation = cacheCreation3
+        }
+
+        // when
+        val result = usageWithCache1 + usageWithCache2
+
+        // then
+        result should {
+            have(inputTokens == 400)
+            have(outputTokens == 600)
+            have(cacheCreation != null)
+        }
+        result.cacheCreation!! should {
+            have(ephemeral5mInputTokens == 40)
+            have(ephemeral1hInputTokens == 60)
+        }
+    }
+
+    @Test
+    fun `should create CacheCreation instance`() {
+        CacheCreation {
+            ephemeral5mInputTokens = 10
+            ephemeral1hInputTokens = 20
+        } should {
+            have(ephemeral5mInputTokens == 10)
+            have(ephemeral1hInputTokens == 20)
+        }
+    }
+
+    @Test
+    fun `should fail to create CacheCreation instance without properties`() {
+        assertFails {
+            CacheCreation {}
+        } should {
+            have(message == "ephemeral5mInputTokens cannot be null")
+        }
+    }
+
+    @Test
+    fun `should return true for equal CacheCreation objects and false for non-equal`() {
+        @Suppress("KotlinConstantConditions")
+        assert(cacheCreation1 == cacheCreation1)
+        assert(cacheCreation1 == cacheCreation2)
+        assert(cacheCreation1 != cacheCreation3)
+    }
+
+    @Test
+    fun `should return the same hashCode for equal CacheCreation objects`() {
+        assert(cacheCreation1.hashCode() == cacheCreation1.hashCode())
+        assert(cacheCreation1.hashCode() == cacheCreation2.hashCode())
+        assert(cacheCreation1.hashCode() != cacheCreation3.hashCode())
+    }
+
+    @Test
+    fun `should add two CacheCreation objects`() {
+        // when
+        val result = cacheCreation1 + cacheCreation3
+
+        // then
+        result should {
+            have(ephemeral5mInputTokens == 40)
+            have(ephemeral1hInputTokens == 60)
+        }
+    }
+
+    @Test
+    fun `should use CacheCreation ZERO constant`() {
+        CacheCreation.ZERO should {
+            have(ephemeral5mInputTokens == 0)
+            have(ephemeral1hInputTokens == 0)
+        }
+    }
+
+    @Test
+    fun `should use Usage ZERO constant`() {
+        Usage.ZERO should {
+            have(inputTokens == 0)
+            have(outputTokens == 0)
+            have(cacheCreationInputTokens == 0)
+            have(cacheReadInputTokens == 0)
+        }
     }
 
 }

--- a/src/jvmTest/java/com/xemantic/ai/anthropic/JavaAnthropicTest.java
+++ b/src/jvmTest/java/com/xemantic/ai/anthropic/JavaAnthropicTest.java
@@ -17,7 +17,7 @@
 package com.xemantic.ai.anthropic;
 
 import com.xemantic.ai.anthropic.message.Role;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/src/jvmTest/kotlin/content/JvmDocumentTest.kt
+++ b/src/jvmTest/kotlin/content/JvmDocumentTest.kt
@@ -25,8 +25,8 @@ import com.xemantic.kotlin.test.be
 import com.xemantic.kotlin.test.have
 import com.xemantic.kotlin.test.should
 import kotlinx.coroutines.test.runTest
-import org.junit.Test
 import java.io.File
+import kotlin.test.Test
 
 class JvmDocumentTest {
 

--- a/src/jvmTest/kotlin/content/JvmImageTest.kt
+++ b/src/jvmTest/kotlin/content/JvmImageTest.kt
@@ -24,8 +24,8 @@ import com.xemantic.kotlin.test.be
 import com.xemantic.kotlin.test.have
 import com.xemantic.kotlin.test.should
 import kotlinx.coroutines.test.runTest
-import org.junit.Test
 import java.io.File
+import kotlin.test.Test
 
 class JvmImageTest {
 


### PR DESCRIPTION
This commit introduces comprehensive updates to handle the latest Anthropic API changes:

- Add UnknownModel data class to support models not in the predefined list
- Update model list: add Claude Sonnet 4.5 (20250929), deprecate older models
- Implement dual cache types: 5-minute and 1-hour ephemeral cache creation
- Update TextEditor tool to str_replace_based_edit_tool (text_editor_20250728)
- Enhance cost tracking with separate cache creation costs for different durations
- Add CacheCreation class for detailed token breakdown by cache duration
- Update all tests to reflect new model IDs and cache structure
- Improve error messaging for unknown models with actionable guidance
- Update dependencies: xemantic-kotlin-test to 1.13.0, conventions plugin to 0.4.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)