### PR TITLE
Add Multi-Provider Support

### DIFF
--- a/src/commonMain/kotlin/Anthropic.kt
+++ b/src/commonMain/kotlin/Anthropic.kt
@@ -42,19 +42,21 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 
 /**
- * The default Anthropic API base.
- */
-const val ANTHROPIC_API_BASE: String = "https://api.anthropic.com/"
-
-/**
  * The default version to be passed to the `anthropic-version` HTTP header of each API request.
  */
 const val DEFAULT_ANTHROPIC_VERSION: String = "2023-06-01"
 
-expect val envApiKey: String?
+/**
+ * Gets the API key for a specific provider from environment variables.
+ * Converts provider name to env var: "anthropic" -> "ANTHROPIC_API_KEY"
+ */
+internal expect fun getEnvApiKey(provider: String): String?
 
-expect val missingApiKeyMessage: String
-
+/**
+ * Gets the API provider to use for testing from the API_PROVIDER_TO_TEST environment variable.
+ * Used by test utilities to select which provider to test against.
+ */
+internal expect val envApiProviderToTest: String?
 
 /**
  * The public constructor function which for the Anthropic API client.
@@ -65,12 +67,20 @@ fun Anthropic(
     block: Anthropic.Config.() -> Unit = {}
 ): Anthropic {
     val config = Anthropic.Config().apply(block)
-    val apiKey = if (config.apiKey != null) config.apiKey else envApiKey
-    if (apiKey == null) {
-        throw AnthropicConfigException(missingApiKeyMessage)
+    val allApiProviders: List<ApiProvider> =
+        StandardApiProvider.entries + config.customApiProviders
+    val availableApiKeys: Map<String, String> = allApiProviders.mapNotNull { info ->
+        val apiKey = getEnvApiKey(info.id)
+        apiKey?.let { info.id to it }
+    }.toMap()
+    if (config.apiKey == null && availableApiKeys.isEmpty()) {
+        throw AnthropicConfigException(
+            "No API key available. Either provide an explicit apiKey in the config block, " +
+            "or set environment variables for supported providers (e.g., ANTHROPIC_API_KEY, MOONSHOT_API_KEY)."
+        )
     }
     return Anthropic(
-        apiKey = apiKey,
+        apiKey = config.apiKey,
         anthropicVersion = config.anthropicVersion,
         anthropicBeta = if (config.anthropicBeta.isEmpty()) null else config.anthropicBeta.joinToString(","),
         apiBase = config.apiBase,
@@ -79,32 +89,55 @@ fun Anthropic(
         defaultTools = config.defaultTools,
         directBrowserAccess = config.directBrowserAccess,
         logLevel = if (config.logHttp) LogLevel.ALL else LogLevel.NONE,
-        modelMap = config.modelMap
+        modelMap = config.modelMap,
+        availableApiKeys = availableApiKeys
     )
 } // TODO this can be a second constructor, then toolMap can be private
 
 class Anthropic internal constructor(
-    val apiKey: String,
+    val apiKey: String?,
     val anthropicVersion: String,
     val anthropicBeta: String?,
-    val apiBase: String,
+    val apiBase: String?,
     val defaultModel: String,
     val defaultMaxTokens: Int,
     val defaultTools: List<Tool>?,
     val directBrowserAccess: Boolean,
     val logLevel: LogLevel,
-    private val modelMap: Map<String, AnthropicModel>
+    private val modelMap: Map<String, AnthropicModel>,
+    val availableApiKeys: Map<String, String>
 ) {
 
     private val costCollector = CostCollector()
 
     val costWithUsage: CostWithUsage get() = costCollector.costWithUsage
 
+    /**
+     * Holds the effective API configuration for a request.
+     */
+    private data class EffectiveConfig(
+        val apiBase: String,
+        val authHeader: Pair<String, String>
+    )
+
+    /**
+     * Resolves the effective configuration for a model, supporting both
+     * apiKey and apiBase from config and providers (API keys from environment).
+     */
+    private fun getEffectiveConfig(model: AnthropicModel): EffectiveConfig {
+        val effectiveApiBase = apiBase ?: model.apiProvider.apiBase
+        val effectiveApiKey = apiKey ?: availableApiKeys[model.apiProvider.id]
+            ?: error("API key not found for provider '${model.apiProvider.id}'. Please set ${model.apiProvider.id.uppercase().replace("-", "_")}_API_KEY environment variable.")
+
+        val authHeader = model.apiProvider.authHeaderType.createAuthHeader(effectiveApiKey)
+        return EffectiveConfig(effectiveApiBase, authHeader)
+    }
+
     class Config {
         var apiKey: String? = null
         var anthropicVersion: String = DEFAULT_ANTHROPIC_VERSION
         var anthropicBeta: List<String> = emptyList()
-        var apiBase: String = ANTHROPIC_API_BASE
+        var apiBase: String? = null
         var defaultModel: AnthropicModel = Model.DEFAULT
         var defaultMaxTokens: Int = defaultModel.maxOutput
 
@@ -123,6 +156,8 @@ class Anthropic internal constructor(
         operator fun Beta.unaryPlus() {
             anthropicBeta += this.id
         }
+
+        var customApiProviders: List<UnknownApiProvider> = emptyList()
 
     }
 
@@ -180,8 +215,6 @@ class Anthropic internal constructor(
         }
 
         defaultRequest {
-            url(apiBase)
-            header("x-api-key", apiKey)
             header("anthropic-version", anthropicVersion)
             if (anthropicBeta != null) {
                 header("anthropic-beta", anthropicBeta)
@@ -191,6 +224,15 @@ class Anthropic internal constructor(
             }
         }
 
+    }
+
+    /**
+     * Retrieves a model from the modelMap or throws a helpful error.
+     * This validation happens before making API requests to fail fast.
+     */
+    private fun getModelOrThrow(modelId: String): AnthropicModel {
+        return modelMap[modelId]
+            ?: error("Unknown model '$modelId', consider adding modelMap[\"$modelId\"] = UnknownModel(...) when creating Anthropic client instance.")
     }
 
     inner class Messages {
@@ -207,7 +249,12 @@ class Anthropic internal constructor(
         private suspend fun create(
             request: MessageRequest
         ): MessageResponse {
-            val apiResponse = client.post("/v1/messages") {
+            val model = getModelOrThrow(request.model)
+            val config = getEffectiveConfig(model)
+
+            val apiResponse = client.post {
+                url("${config.apiBase}v1/messages")
+                header(config.authHeader.first, config.authHeader.second)
                 contentType(ContentType.Application.Json)
                 setBody(request)
             }
@@ -238,11 +285,15 @@ class Anthropic internal constructor(
                 stream = true
             }.build()
 
+            val model = getModelOrThrow(request.model)
+            val config = getEffectiveConfig(model)
+
             try {
                 client.sse(
-                    urlString = "/v1/messages",
+                    urlString = "${config.apiBase}v1/messages",
                     request = {
                         method = HttpMethod.Post
+                        header(config.authHeader.first, config.authHeader.second)
                         contentType(ContentType.Application.Json)
                         setBody(request)
                     }
@@ -295,12 +346,12 @@ class Anthropic internal constructor(
 
     val messages = Messages()
 
+    /**
+     * Gets the model definition from the response.
+     * Note: This should always succeed since we validate the model exists before making requests.
+     */
     private val MessageResponse.anthropicModel: AnthropicModel
-        get() = requireNotNull(
-            modelMap[model]
-        ) {
-            "Unknown model '$model', consider adding modelMap[\"$model\"] = UnknownModel(...) when creating Anthropic client instance."
-        }
+        get() = getModelOrThrow(model)
 
     override fun toString(): String = "Anthropic($costWithUsage)"
 }

--- a/src/commonMain/kotlin/Models.kt
+++ b/src/commonMain/kotlin/Models.kt
@@ -32,6 +32,7 @@ interface AnthropicModel {
     val messageBatchesApi: Boolean
     val cost: Cost
     val deprecated: Boolean
+    val apiProvider: ApiProvider
 
 }
 
@@ -50,7 +51,8 @@ enum class Model(
     override val maxOutput: Int,
     override val messageBatchesApi: Boolean,
     override val cost: Cost,
-    override val deprecated: Boolean = false
+    override val deprecated: Boolean = false,
+    override val apiProvider: ApiProvider = StandardApiProvider.ANTHROPIC,
 ) : AnthropicModel {
 
     CLAUDE_SONNET_4_5_20250929(
@@ -163,6 +165,30 @@ enum class Model(
             inputTokens = "0.25".dollarsPerMillion
             outputTokens = "1.25".dollarsPerMillion
         }
+    ),
+
+    KIMI_K2_0905_PREVIEW(
+        id = "kimi-k2-0905-preview",
+        contextWindow = 262144,
+        maxOutput = 32768,
+        messageBatchesApi = true,
+        cost = Cost {
+            inputTokens = "0.6".dollarsPerMillion
+            outputTokens = "2.50".dollarsPerMillion
+        },
+        apiProvider = StandardApiProvider.MOONSHOT
+    ),
+
+    KIMI_K2_THINKING(
+        id = "kimi-k2-thinking",
+        contextWindow = 262144,
+        maxOutput = 32768,
+        messageBatchesApi = true,
+        cost = Cost {
+            inputTokens = "0.6".dollarsPerMillion
+            outputTokens = "2.50".dollarsPerMillion
+        },
+        apiProvider = StandardApiProvider.MOONSHOT
     );
 
     companion object {
@@ -179,5 +205,6 @@ data class UnknownModel(
     override val maxOutput: Int,
     override val messageBatchesApi: Boolean,
     override val cost: Cost,
-    override val deprecated: Boolean = false
+    override val deprecated: Boolean = false,
+    override val apiProvider: ApiProvider = StandardApiProvider.ANTHROPIC,
 ) : AnthropicModel

--- a/src/commonMain/kotlin/Providers.kt
+++ b/src/commonMain/kotlin/Providers.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Xemantic contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.ai.anthropic
+
+enum class AuthHeaderType {
+    /** Uses `x-api-key: {key}` header (Anthropic). */
+    X_API_KEY,
+
+    /** Uses `Authorization: Bearer {key}` header (Moonshot, OpenRouter, etc.). */
+    BEARER_TOKEN;
+
+    fun createAuthHeader(apiKey: String): Pair<String, String> = when (this) {
+        X_API_KEY -> "x-api-key" to apiKey
+        BEARER_TOKEN -> "Authorization" to "Bearer $apiKey"
+    }
+}
+
+interface ApiProvider {
+    val id: String
+    val apiBase: String
+    val authHeaderType: AuthHeaderType
+}
+
+enum class StandardApiProvider(
+    override val id: String,
+    override val apiBase: String,
+    override val authHeaderType: AuthHeaderType
+) : ApiProvider {
+
+    ANTHROPIC(
+        id = "anthropic",
+        apiBase = "https://api.anthropic.com/",
+        authHeaderType = AuthHeaderType.X_API_KEY
+    ),
+
+    MOONSHOT(
+        id = "moonshot",
+        apiBase = "https://api.moonshot.ai/anthropic/",
+        authHeaderType = AuthHeaderType.BEARER_TOKEN
+    )
+
+}
+
+data class UnknownApiProvider(
+    override val id: String,
+    override val apiBase: String,
+    override val authHeaderType: AuthHeaderType
+) : ApiProvider

--- a/src/commonMain/kotlin/Responses.kt
+++ b/src/commonMain/kotlin/Responses.kt
@@ -19,8 +19,23 @@ package com.xemantic.ai.anthropic
 import com.xemantic.ai.anthropic.json.toPrettyJson
 import kotlinx.serialization.Serializable
 
+/**
+ * Base class for all API responses.
+ *
+ * The `type` field defaults to "error" to handle provider compatibility:
+ * - Anthropic API returns: `{ "type": "error", "error": {...} }`
+ * - Some compatible providers (e.g., Moonshot) omit the `type` field: `{ "error": {...} }`
+ *
+ * When the `type` field is missing from the JSON response, kotlinx.serialization
+ * will use the default value. Since responses without an explicit type typically
+ * occur in error scenarios, defaulting to "error" provides graceful handling
+ * of non-compliant but compatible API providers.
+ *
+ * Simply put, if the response doesn't have a valid `type` it should be treated
+ * like error anyway.
+ */
 @Serializable
-abstract class Response(val type: String) {
+abstract class Response(val type: String = "error") {
 
     override fun toString() = toPrettyJson()
 

--- a/src/commonTest/kotlin/AnthropicTest.kt
+++ b/src/commonTest/kotlin/AnthropicTest.kt
@@ -236,18 +236,18 @@ class AnthropicTest {
     fun `should fail with a message when creating a message request for unknown model`() = runTest {
         // given
         val anthropic = testAnthropic {
-            modelMap.remove(Model.DEFAULT.id)
+            modelMap.remove(defaultModel.id)
         }
 
         // when
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<IllegalStateException> {
             anthropic.messages.create {
                 +"Hello World! What's your name?"
             }
         }
 
         // then
-        assert(exception.message == "Unknown model '${Model.DEFAULT.id}', consider adding modelMap[\"${Model.DEFAULT.id}\"] = UnknownModel(...) when creating Anthropic client instance.")
+        assert(exception.message == "Unknown model '${anthropic.defaultModel}', consider adding modelMap[\"${anthropic.defaultModel}\"] = UnknownModel(...) when creating Anthropic client instance.")
     }
 
 }

--- a/src/commonTest/kotlin/MultiProviderTest.kt
+++ b/src/commonTest/kotlin/MultiProviderTest.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2024-2025 Kazimierz Pogoda / Xemantic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.ai.anthropic
+
+import com.xemantic.ai.anthropic.cost.Cost
+import com.xemantic.ai.anthropic.error.AnthropicApiException
+import com.xemantic.ai.anthropic.message.Role
+import com.xemantic.ai.anthropic.message.StopReason
+import com.xemantic.kotlin.test.have
+import com.xemantic.kotlin.test.should
+import io.ktor.http.*
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class MultiProviderTest {
+
+    @Test
+    fun `should use Anthropic model with ANTHROPIC_API_KEY`() = runTest {
+        val anthropicKey = getEnvApiKey("anthropic")
+        if (anthropicKey == null) {
+            println("⊘ Skipping: ANTHROPIC_API_KEY not set")
+            return@runTest
+        }
+
+        val client = Anthropic()
+
+        val response = client.messages.create {
+            model = Model.CLAUDE_SONNET_4_5_20250929.id
+            maxTokens = 50
+            +"Say hello"
+        }
+
+        response should {
+            have(role == Role.ASSISTANT)
+            have("claude" in model)
+            have(stopReason == StopReason.END_TURN)
+        }
+    }
+
+    @Test
+    fun `should use Moonshot model with MOONSHOT_API_KEY`() = runTest {
+        val moonshotKey = getEnvApiKey("moonshot")
+        if (moonshotKey == null) {
+            println("⊘ Skipping: MOONSHOT_API_KEY not set")
+            return@runTest
+        }
+
+        val client = Anthropic()
+
+        val response = client.messages.create {
+            model = Model.KIMI_K2_0905_PREVIEW.id
+            maxTokens = 50
+            +"Say hello"
+        }
+
+        response should {
+            have(role == Role.ASSISTANT)
+            have("kimi" in model)
+            have(stopReason == StopReason.END_TURN)
+        }
+    }
+
+    @Test
+    fun `should switch between Anthropic and Moonshot models`() = runTest {
+        val anthropicKey = getEnvApiKey("anthropic")
+        val moonshotKey = getEnvApiKey("moonshot")
+
+        if (anthropicKey == null || moonshotKey == null) {
+            println("⊘ Skipping: Requires both ANTHROPIC_API_KEY and MOONSHOT_API_KEY")
+            return@runTest
+        }
+
+        val client = Anthropic()
+
+        // Use Anthropic model
+        val anthropicResponse = client.messages.create {
+            model = Model.CLAUDE_SONNET_4_5_20250929.id
+            maxTokens = 50
+            +"Say 'Hello from Anthropic'"
+        }
+
+        anthropicResponse should {
+            have("claude" in model)
+        }
+
+        // Use Moonshot model
+        val moonshotResponse = client.messages.create {
+            model = Model.KIMI_K2_0905_PREVIEW.id
+            maxTokens = 50
+            +"Say 'Hello from Moonshot'"
+        }
+
+        moonshotResponse should {
+            have("kimi" in model)
+        }
+    }
+
+    @Test
+    fun `should use explicit apiKey and fail with auth error when key is invalid`() = runTest {
+        val client = Anthropic {
+            apiKey = "sk-ant-fake-key-12345"  // Fake API key
+        }
+
+        val exception = assertFailsWith<AnthropicApiException> {
+            client.messages.create {
+                model = Model.CLAUDE_SONNET_4_5_20250929.id
+                maxTokens = 50
+                +"Say hello"
+            }
+        }
+
+        // Should be 401 Unauthorized, proving our fake key was used
+        exception.httpStatusCode should {
+            have(this == HttpStatusCode.Unauthorized)
+        }
+    }
+
+    @Test
+    fun `should use explicit apiBase and fail when endpoint is wrong`() = runTest {
+        val apiKey = getEnvApiKey("anthropic")
+        if (apiKey == null) {
+            println("⊘ Skipping: ANTHROPIC_API_KEY not set")
+            return@runTest
+        }
+
+        val client = Anthropic {
+            this.apiKey = apiKey
+            this.apiBase = "https://wrong-endpoint.example.com/"
+        }
+
+        // Should fail because wrong endpoint is used
+        assertFailsWith<Exception> {
+            client.messages.create {
+                model = Model.CLAUDE_SONNET_4_5_20250929.id
+                maxTokens = 50
+                +"Say hello"
+            }
+        }
+    }
+
+    @Test
+    fun `should fail when custom provider API key is not available`() = runTest {
+        val customProvider = UnknownApiProvider(
+            id = "nonexistent-provider",
+            apiBase = "https://api.example.com/",
+            authHeaderType = AuthHeaderType.BEARER_TOKEN
+        )
+
+        val customModel = UnknownModel(
+            id = "custom-model",
+            apiProvider = customProvider,
+            contextWindow = 100000,
+            maxOutput = 4096,
+            messageBatchesApi = true,
+            cost = Cost {
+                inputTokens = "3".dollarsPerMillion
+                outputTokens = "15".dollarsPerMillion
+            },
+        )
+
+        val client = Anthropic {
+            customApiProviders = listOf(customProvider)
+            modelMap["custom-model"] = customModel
+        }
+
+        val exception = assertFailsWith<IllegalStateException> {
+            client.messages.create {
+                model = "custom-model"
+                maxTokens = 50
+                +"Say hello"
+            }
+        }
+
+        exception.message!! should {
+            have(contains("API key not found for provider 'nonexistent-provider'"))
+            have(contains("NONEXISTENT_PROVIDER_API_KEY"))
+        }
+    }
+}

--- a/src/commonTest/kotlin/test/TestSupport.kt
+++ b/src/commonTest/kotlin/test/TestSupport.kt
@@ -17,15 +17,49 @@
 package com.xemantic.ai.anthropic.test
 
 import com.xemantic.ai.anthropic.Anthropic
+import com.xemantic.ai.anthropic.Model
+import com.xemantic.ai.anthropic.envApiProviderToTest
 import com.xemantic.kotlin.test.gradleRootDir
 import com.xemantic.kotlin.test.isBrowserPlatform
 import kotlinx.io.files.Path
 
 val testDataDir: Path get() = Path(gradleRootDir, "test-data")
 
+/**
+ * Creates an Anthropic client for testing.
+ *
+ * By default, uses Anthropic's Claude models. To test with other providers,
+ * set the API_PROVIDER_TO_TEST environment variable:
+ *
+ * - `API_PROVIDER_TO_TEST=anthropic` or omitted: Uses Claude Sonnet 4.5 (default)
+ * - `API_PROVIDER_TO_TEST=moonshot`: Uses Kimi K2 0905 Preview
+ *
+ * Example:
+ * ```bash
+ * # Test with Anthropic (default)
+ * ./gradlew test
+ *
+ * # Test with Moonshot
+ * API_PROVIDER_TO_TEST=moonshot ./gradlew test
+ * ```
+ *
+ * The provider's API key must be available as an environment variable
+ * (ANTHROPIC_API_KEY, MOONSHOT_API_KEY, etc.).
+ */
 fun testAnthropic(
     block: Anthropic.Config.() -> Unit = {}
 ): Anthropic = Anthropic {
+    val testProvider = envApiProviderToTest?.lowercase()
+
+    if (testProvider != null && testProvider != "anthropic") {
+        val model = when (testProvider) {
+            "moonshot" -> Model.KIMI_K2_0905_PREVIEW
+            else -> error("Unknown API_PROVIDER_TO_TEST: $testProvider. Supported: anthropic, moonshot")
+        }
+        defaultModel = model
+        println("🧪 Testing with provider: $testProvider, model: ${model.id}")
+    }
+
     block()
     directBrowserAccess = isBrowserPlatform
 }

--- a/src/jsMain/kotlin/JsAnthropic.kt
+++ b/src/jsMain/kotlin/JsAnthropic.kt
@@ -1,7 +1,9 @@
 package com.xemantic.ai.anthropic
 
-actual val envApiKey: String?
-    get() = js("process.env.ANTHROPIC_API_KEY")
+internal actual fun getEnvApiKey(provider: String): String? {
+    val envVarName = "${provider.uppercase().replace("-", "_")}_API_KEY"
+    return js("process.env[envVarName]")
+}
 
-actual val missingApiKeyMessage: String
-    get() = "apiKey is missing, it has to be provided as a parameter."
+internal actual val envApiProviderToTest: String?
+    get() = js("process.env.API_PROVIDER_TO_TEST")

--- a/src/jvmMain/kotlin/Anthropic.jvm.kt
+++ b/src/jvmMain/kotlin/Anthropic.jvm.kt
@@ -16,8 +16,10 @@
 
 package com.xemantic.ai.anthropic
 
-actual val envApiKey: String?
-    get() = System.getenv("ANTHROPIC_API_KEY")
+internal actual fun getEnvApiKey(provider: String): String? {
+    val envVarName = "${provider.uppercase().replace("-", "_")}_API_KEY"
+    return System.getenv(envVarName)
+}
 
-actual val missingApiKeyMessage: String
-    get() = "apiKey is missing, it has to be provided as a parameter or as an ANTHROPIC_API_KEY environment variable."
+internal actual val envApiProviderToTest: String?
+    get() = System.getenv("API_PROVIDER_TO_TEST")

--- a/src/nativeMain/kotlin/NativeAnthropic.kt
+++ b/src/nativeMain/kotlin/NativeAnthropic.kt
@@ -5,8 +5,11 @@ import kotlinx.cinterop.toKString
 import platform.posix.getenv
 
 @OptIn(ExperimentalForeignApi::class)
-actual val envApiKey: String?
-    get() = getenv("ANTHROPIC_API_KEY")?.toKString()
+internal actual fun getEnvApiKey(provider: String): String? {
+    val envVarName = "${provider.uppercase().replace("-", "_")}_API_KEY"
+    return getenv(envVarName)?.toKString()
+}
 
-actual val missingApiKeyMessage: String
-    get() = "apiKey is missing, it has to be provided as a parameter or as an ANTHROPIC_API_KEY environment variable."
+@OptIn(ExperimentalForeignApi::class)
+internal actual val envApiProviderToTest: String?
+    get() = getenv("API_PROVIDER_TO_TEST")?.toKString()

--- a/src/wasmJsMain/kotlin/WasmJsAnthropic.kt
+++ b/src/wasmJsMain/kotlin/WasmJsAnthropic.kt
@@ -1,9 +1,9 @@
 package com.xemantic.ai.anthropic
 
-actual val envApiKey: String?
-    get() = getenv("ANTHROPIC_API_KEY")
+internal actual fun getEnvApiKey(provider: String): String? {
+    val envVarName = "${provider.uppercase().replace("-", "_")}_API_KEY"
+    return js("process.env[envVarName]")
+}
 
-actual val missingApiKeyMessage: String
-    get() = "apiKey is missing, it has to be provided as a parameter."
-
-private fun getenv(name: String): String? = js("process.env[name]")
+internal actual val envApiProviderToTest: String?
+    get() = js("process.env.API_PROVIDER_TO_TEST")


### PR DESCRIPTION
## Overview

This PR adds comprehensive multi-provider support to the Anthropic SDK, enabling seamless switching between Anthropic's Claude models and API-compatible providers like Moonshot's Kimi models. The implementation maintains backward compatibility while introducing a flexible, extensible provider architecture with auto-detection of available API keys.

## Key Features

### 1. **Provider Architecture** (New: `Providers.kt`)
- **`ApiProvider` interface** - Common interface for all API providers
- **`StandardApiProvider` enum** - Built-in providers (Anthropic, Moonshot)
- **`UnknownApiProvider` data class** - Support for custom providers
- **`AuthHeaderType` enum** - Handles different authentication methods:
  - `X_API_KEY` - Anthropic's `x-api-key: {key}` header
  - `BEARER_TOKEN` - Moonshot's `Authorization: Bearer {key}` header
- **`createAuthHeader()` method** - Centralized auth header generation (eliminates duplication)

### 2. **Two Kimi K2 Models Added**
- **`KIMI_K2_0905_PREVIEW`** - 262K context, 32K max output
- **`KIMI_K2_THINKING`** - 262K context, 32K max output  
- Cost: $0.60/M input, $2.50/M output tokens
- Uses Moonshot provider with Bearer token authentication
- IMPORTANT: Not every features documented in Anthropic API are available for Kimi models, such as Tool Use or Caching

### 3. **Auto-Detection of Available Providers**
The SDK now automatically scans environment variables at initialization:
- Convention: `{PROVIDER}_API_KEY` (e.g., `ANTHROPIC_API_KEY`, `MOONSHOT_API_KEY`)
- Only available providers are registered (no errors if keys missing)
- Stored in `availableApiKeys: Map<String, String>` for O(1) lookup

### 4. **Backward Compatibility**
Explicit configuration still works as before:

```kotlin
Anthropic {
    apiKey = "sk-ant-..."  // Optional
    apiBase = "https://..."  // Optional
}
```

Both apiKey and apiBase are now nullable and fall back to provider-based resolution.

### 5. Flexible Request Resolution

New getEffectiveConfig() method resolves configuration per request:
- Explicit config takes precedence
- Falls back to provider auto-detection
- Clear error messages if API key not found

### 6. Provider Compatibility

Error Response Handling (Responses.kt):
- Made type field default to "error"
- Handles providers that omit the type field (like Moonshot)
- Extensive documentation explaining the compatibility reasoning

### 7. Enhanced Testing Infrastructure

New: MultiProviderTest.kt (194 lines, 6 tests):
1. ✅ Use Anthropic model with ANTHROPIC_API_KEY
2. ✅ Use Moonshot model with MOONSHOT_API_KEY
3. ✅ Switch between providers with single client
4. ✅ Explicit apiKey validation (negative test with fake key → 401)
5. ✅ Explicit apiBase validation (negative test with wrong endpoint)
6. ✅ Custom provider validation (negative test for missing API key)

Updated: TestSupport.kt:
- New testAnthropic() helper supports API_PROVIDER_TO_TEST env var
- Documentation with usage examples
- All existing tests can run against any provider
  - However, it's not guaranteed that all test for any provider will pass. Some tests expect Claude models to respond specifically, but other than that, third-party providers might simply implement their API differently.

### 8. Platform-specific Environmental Variables

Platform files (JVM, JS, Native, WasmJs):
- Removed: envApiKey (unused, replaced by provider-specific lookup)
- Removed: missingApiKeyMessage (inlined with better multi-provider message)
- Added: internal fun getEnvApiKey(provider) - Scoped to specific providers only
- Added: internal val envApiProviderToTest - Specific test configuration property
- Security: No arbitrary environment variable access

## Breaking Changes

### 1. Internal API Changes (Non-Breaking for Public API)

- envApiKey removed (was internal/undocumented)
- missingApiKeyMessage removed (was internal)
- ANTHROPIC_API_BASE constant removed (no longer needed)
- Models now have apiProvider: ApiProvider field

For Public API everything works exactly as before.

## To Use Multiple Providers

```
# Set environment variables
export ANTHROPIC_API_KEY=sk-ant-...
export MOONSHOT_API_KEY=sk-...
```

```kotlin
val client = Anthropic()

// Use Anthropic
client.messages.create {
    model = Model.CLAUDE_SONNET_4_5_20250929.id
    +"Hello"
}

// Use Moonshot
client.messages.create {
    model = Model.KIMI_K2_0905_PREVIEW.id
    +"Hello"
}
```

## To Add Custom Providers

```kotlin
Anthropic {
    customApiProviders = listOf(
        UnknownApiProvider(
            id = "custom",
            apiBase = "https://api.custom.com/",
            authHeaderType = AuthHeaderType.BEARER_TOKEN
        )
    )
    modelMap["custom-model"] = UnknownModel(
        id = "custom-model",
        apiProvider = /* reference to custom or pre-defined provider */,
        contextWindow = 100000,
        maxOutput = 4096,
        messageBatchesApi = true,
        cost = Cost { /* ... */ }
    )
}
```

## Testing

```bash
# Test multi-provider integration (skips tests without proper API keys)
./gradlew :jvmTest --tests "MultiProviderTest"

# Run all tests against Moonshot
API_PROVIDER_TO_TEST=moonshot ./gradlew :jvmTest
```
