### PR TITLE
Use central reusable workflow for branch builds

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -14,6 +14,6 @@ jobs:
     uses: xemantic/.github/.github/workflows/build-gradle.yml@main
     with:
       gradle_args: build
-      env: |
+    secrets:
+      env_secrets: |
         ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-    secrets: inherit

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -11,21 +11,9 @@ on:
 
 jobs:
   build_branch:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v6.0.1
-
-      - name: Setup Java
-        uses: actions/setup-java@v5.1.0
-        with:
-          distribution: ${{ vars.DEFAULT_JAVA_DISTRIBUTION }}
-          java-version: ${{ vars.DEFAULT_JAVA_VERSION }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5.0.0
-
-      - name: Build
-        run: ./gradlew build
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    uses: xemantic/.github/.github/workflows/build-gradle.yml@main
+    with:
+      gradle_args: build
+      env: |
+        ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replace inline job steps in `build-branch.yml` with the centralized reusable workflow from `xemantic/.github`
- Use `build-gradle.yml@main` for consistent build configuration across repositories

## Test plan
- [ ] Verify the workflow runs successfully on this PR
- [ ] Confirm build completes with same behavior as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)