### PR TITLE
Make CacheControl parameter non-nullable with default value in addCacheBreakpoint

### DIFF
--- a/src/commonMain/kotlin/message/Messages.kt
+++ b/src/commonMain/kotlin/message/Messages.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Kazimierz Pogoda / Xemantic
+ * Copyright 2024-2026 Xemantic contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -313,12 +313,12 @@ data class MessageResponse(
 }
 
 fun List<Message>.addCacheBreakpoint(
-    cacheControl: CacheControl? = null
+    cacheControl: CacheControl = CacheControl.Ephemeral()
 ): List<Message> = mapLast { message ->
     message.copy {
         content = content.mapLast { contentElement ->
             contentElement.alterCacheControl(
-                cacheControl ?: CacheControl.Ephemeral()
+                cacheControl = cacheControl
             )
         }
     }


### PR DESCRIPTION
## Summary
- Change `addCacheBreakpoint()` parameter type from `CacheControl?` to `CacheControl` with a default value of `CacheControl.Ephemeral()`
- Simplify function implementation by removing null coalescing
- Update copyright header to 2026

## Test plan
- [ ] Verify existing tests pass with `./gradlew build`
- [ ] Confirm API behavior remains unchanged (same default behavior when called without arguments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)