### PR TITLE
Update dependencies and simplify maven publishing configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,8 +16,6 @@
 
 @file:OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalWasmDsl::class)
 
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.KotlinMultiplatform
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -299,25 +297,8 @@ dokka {
 
 mavenPublishing {
 
-    configure(
-        KotlinMultiplatform(
-            javadocJar = JavadocJar.Dokka("dokkaGenerateHtml"),
-            sourcesJar = true
-        )
-    )
-
+    publishToMavenCentral(automaticRelease = true)
     signAllPublications()
-
-    publishToMavenCentral(
-        automaticRelease = true,
-        validateDeployment = false // for kotlin multiplatform projects it might take a while (>900s)
-    )
-
-    coordinates(
-        groupId = group.toString(),
-        artifactId = rootProject.name,
-        version = version.toString()
-    )
 
     pom {
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,23 +5,23 @@ javaTarget = "17"
 # jetbrains
 kotlin = "2.2.21"
 kotlinxCoroutines = "1.10.2"
-kotlinxSerialization = "1.9.0"
-ktor = "3.3.3"
+kotlinxSerialization = "1.10.0"
+ktor = "3.4.0"
 
 # xemantic
 xemanticKotlinCore = "0.6.4"
-xemanticKotlinTest = "1.16.0"
+xemanticKotlinTest = "1.17.1"
 xemanticAiToolSchema = "1.2.0"
 xemanticAiMoney = "0.2"
 xemanticAiFileMagic = "0.4.0"
 
 # logging
 slf4j = "2.0.17"
-logback = "1.5.23"
+logback = "1.5.25"
 
 versionsPlugin = "0.53.0"
 dokkaPlugin = "2.1.0"
-mavenPublishPlugin = "0.35.0"
+mavenPublishPlugin = "0.36.0"
 jreleaserPlugin = "1.22.0"
 xemanticConventionsPlugin = "0.6.8"
 


### PR DESCRIPTION
## Summary
- Update kotlinx-serialization to 1.10.0
- Update Ktor to 3.4.0
- Update xemantic-kotlin-test to 1.17.1
- Update logback to 1.5.25
- Update maven-publish plugin to 0.36.0
- Simplify mavenPublishing block by using plugin defaults

## Test plan
- [ ] Build passes with `./gradlew build`
- [ ] Tests pass with valid API key
- [ ] Publishing configuration still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)