### PR TITLE
Downgrade ktor from 3.4.0 to 3.3.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ javaTarget = "17"
 kotlin = "2.2.21"
 kotlinxCoroutines = "1.10.2"
 kotlinxSerialization = "1.10.0"
-ktor = "3.4.0"
+ktor = "3.3.3"
 
 # xemantic
 xemanticKotlinCore = "0.6.4"


### PR DESCRIPTION
## Summary
- Downgrades ktor dependency from 3.4.0 to 3.3.3

## Test plan
- [ ] Verify build passes with `./gradlew build`
- [ ] Run tests to ensure HTTP client functionality works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)