### PR TITLE
Downgrade kotlinx-serialization from 1.10.0 to 1.9.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,8 @@ javaTarget = "17"
 # jetbrains
 kotlin = "2.2.21"
 kotlinxCoroutines = "1.10.2"
-kotlinxSerialization = "1.10.0"
+# don't upgrade these 2 until kotlin-2.3.10 is released with native linux compilaiton hang fix
+kotlinxSerialization = "1.9.0"
 ktor = "3.3.3"
 
 # xemantic


### PR DESCRIPTION
## Summary
- Downgrade kotlinx-serialization from 1.10.0 to 1.9.0 to avoid native Linux compilation hangs
- This is a temporary workaround until kotlin-2.3.10 is released with the fix

## Test plan
- [ ] Verify build passes with `./gradlew build`
- [ ] Verify native compilation completes without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)