### PR TITLE
Update xemantic-kotlin-test from 1.17.1 to 1.17.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ ktor = "3.3.3"
 
 # xemantic
 xemanticKotlinCore = "0.6.4"
-xemanticKotlinTest = "1.17.1"
+xemanticKotlinTest = "1.17.2"
 xemanticAiToolSchema = "1.2.0"
 xemanticAiMoney = "0.2"
 xemanticAiFileMagic = "0.4.0"


### PR DESCRIPTION
## Summary
- Bump xemantic-kotlin-test dependency from version 1.17.1 to 1.17.2

## Test plan
- [ ] Verify build passes with updated dependency
- [ ] Ensure existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)