### PR TITLE
Update workflows to use secrets inherit and fix WasmJs experimental opt-in

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     uses: xemantic/.github/.github/workflows/build-gradle.yml@main
     secrets:
-      env_secrets: |
-        ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
+      inherit
     with:
       gradle_args: -PjvmOnlyBuild=false build publishToMavenCentral --no-configuration-cache
       maven_central: true
+      anthropic: true

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     uses: xemantic/.github/.github/workflows/build-gradle.yml@main
     secrets:
-      env_secrets: |
-        ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
+      inherit
     with:
       gradle_args: build -PjvmOnlyBuild=true
+      anthropic: true

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,9 +19,9 @@ jobs:
     needs: extract_version
     uses: xemantic/.github/.github/workflows/build-gradle.yml@main
     secrets:
-      env_secrets: |
-        ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
+      inherit
     with:
       gradle_args: -Pversion=${{ needs.extract_version.outputs.version }} -PjvmOnlyBuild=false build publishToMavenCentral jreleaserAnnounce --no-configuration-cache
       maven_central: true
       jreleaser: true
+      anthropic: true

--- a/src/wasmJsMain/kotlin/WasmJsAnthropic.kt
+++ b/src/wasmJsMain/kotlin/WasmJsAnthropic.kt
@@ -6,4 +6,5 @@ actual val envApiKey: String?
 actual val missingApiKeyMessage: String
     get() = "apiKey is missing, it has to be provided as a parameter."
 
+@OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
 private fun getenv(name: String): String? = js("process.env[name]")

--- a/src/wasmJsMain/kotlin/WasmJsAnthropic.kt
+++ b/src/wasmJsMain/kotlin/WasmJsAnthropic.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2026 Xemantic contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.xemantic.ai.anthropic
 
 actual val envApiKey: String?


### PR DESCRIPTION
## Summary
- Use `secrets: inherit` instead of explicit `env_secrets` in all workflow files
- Add `anthropic: true` input parameter to workflows
- Add `@OptIn(ExperimentalWasmJsInterop::class)` annotation in WasmJsAnthropic.kt

## Test plan
- [ ] Verify PR build workflow passes
- [ ] Verify WasmJs compilation succeeds without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)