### PR TITLE
Add Claude Opus 4.6 model

### DIFF
--- a/src/commonMain/kotlin/Models.kt
+++ b/src/commonMain/kotlin/Models.kt
@@ -67,6 +67,18 @@ enum class Model(
         cacheMinTokens = 1024
     ),
 
+    CLAUDE_OPUS_4_6(
+        id = "claude-opus-4-6",
+        contextWindow = 200000,
+        maxOutput = 128000,
+        messageBatchesApi = true,
+        cost = Cost {
+            inputTokens = "5".dollarsPerMillion
+            outputTokens = "25".dollarsPerMillion
+        },
+        cacheMinTokens = 1024
+    ),
+
     CLAUDE_OPUS_4_5_20251101(
         id = "claude-opus-4-5-20251101",
         contextWindow = 200000,


### PR DESCRIPTION
Adds the new Claude Opus 4.6 model to the SDK with accurate pricing and specifications.

## Changes
- Added `CLAUDE_OPUS_4_6` enum entry to Models.kt
- Model ID: `claude-opus-4-6`
- Context window: 200K tokens
- Max output: 128K tokens (doubled from 64K)
- Message Batches API: Supported
- Pricing: $5/MTok input, $25/MTok output

Resolves #126

Generated with [Claude Code](https://claude.ai/code)