### PR TITLE
feat: add Claude Sonnet 4.6 model

### DIFF
--- a/src/commonMain/kotlin/Models.kt
+++ b/src/commonMain/kotlin/Models.kt
@@ -55,6 +55,18 @@ enum class Model(
     override val cacheMinTokens: Int
 ) : AnthropicModel {
 
+    CLAUDE_SONNET_4_6(
+        id = "claude-sonnet-4-6",
+        contextWindow = 200000,
+        maxOutput = 64000,
+        messageBatchesApi = true,
+        cost = Cost {
+            inputTokens = "3".dollarsPerMillion
+            outputTokens = "15".dollarsPerMillion
+        },
+        cacheMinTokens = 1024
+    ),
+
     CLAUDE_SONNET_4_5_20250929(
         id = "claude-sonnet-4-5-20250929",
         contextWindow = 200000,
@@ -217,7 +229,7 @@ enum class Model(
 
     companion object {
 
-        val DEFAULT: Model = CLAUDE_SONNET_4_5_20250929
+        val DEFAULT: Model = CLAUDE_SONNET_4_6
 
     }
 

--- a/src/commonTest/kotlin/message/MessageRequestTest.kt
+++ b/src/commonTest/kotlin/message/MessageRequestTest.kt
@@ -43,7 +43,7 @@ class MessageRequestTest {
         // then
         json sameAsJson """
             {
-              "model": "claude-sonnet-4-5-20250929",
+              "model": "claude-sonnet-4-6",
               "messages": [
                 {
                   "role": "user",
@@ -77,7 +77,7 @@ class MessageRequestTest {
         // then
         json sameAsJson """
             {
-              "model": "claude-sonnet-4-5-20250929",
+              "model": "claude-sonnet-4-6",
               "messages": [
                 {
                   "role": "user",
@@ -111,7 +111,7 @@ class MessageRequestTest {
         // then
         json sameAsJson """
             {
-              "model": "claude-sonnet-4-5-20250929",
+              "model": "claude-sonnet-4-6",
               "messages": [
                 {
                   "role": "user",
@@ -175,7 +175,7 @@ class MessageRequestTest {
         // then
         json sameAsJson """
             {
-              "model": "claude-sonnet-4-5-20250929",
+              "model": "claude-sonnet-4-6",
               "messages": [
                 {
                   "role": "user",
@@ -254,7 +254,7 @@ class MessageRequestTest {
         // then
         json sameAsJson """
             {
-              "model": "claude-sonnet-4-5-20250929",
+              "model": "claude-sonnet-4-6",
               "messages": [
                 {
                   "role": "user",


### PR DESCRIPTION
Adds CLAUDE_SONNET_4_6 model with model ID "claude-sonnet-4-6" based on official Anthropic documentation.

Changes:
- Added CLAUDE_SONNET_4_6 entry in Models.kt
- Updated DEFAULT to CLAUDE_SONNET_4_6

Specs: 200K context window, 64K max output, $3/MTok input, $15/MTok output

Closes #128

Generated with [Claude Code](https://claude.ai/code)