### PR TITLE
refactor: migrate top-level factory functions to TypeName.Companion.invoke

### DIFF
--- a/src/commonMain/kotlin/content/Document.kt
+++ b/src/commonMain/kotlin/content/Document.kt
@@ -60,6 +60,55 @@ class Document private constructor(
             MediaType.PDF, MediaType.TEXT
         )
 
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            block: Document.Builder.() -> Unit
+        ): Document {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return Document.Builder().apply(block).build()
+        }
+
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            path: String,
+            block: Document.Builder.() -> Unit = {}
+        ): Document {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return Document(Path(path), block)
+        }
+
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            path: Path,
+            block: Document.Builder.() -> Unit = {}
+        ): Document {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return Document {
+                this.path = path
+                block(this)
+            }
+        }
+
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            bytes: ByteArray,
+            block: Document.Builder.() -> Unit = {}
+        ): Document {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return Document {
+                this.bytes = bytes
+                block(this)
+            }
+        }
+
     }
 
     @OptIn(ExperimentalContracts::class)
@@ -76,53 +125,4 @@ class Document private constructor(
         }.build()
     }
 
-}
-
-@OptIn(ExperimentalContracts::class)
-fun Document(
-    block: Document.Builder.() -> Unit
-): Document {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-    }
-    return Document.Builder().apply(block).build()
-}
-
-@OptIn(ExperimentalContracts::class)
-fun Document(
-    path: String,
-    block: Document.Builder.() -> Unit = {}
-): Document {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-    }
-    return Document(Path(path), block)
-}
-
-@OptIn(ExperimentalContracts::class)
-fun Document(
-    path: Path,
-    block: Document.Builder.() -> Unit = {}
-): Document {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-    }
-    return Document {
-        this.path = path
-        block(this)
-    }
-}
-
-@OptIn(ExperimentalContracts::class)
-fun Document(
-    bytes: ByteArray,
-    block: Document.Builder.() -> Unit = {}
-): Document {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-    }
-    return Document {
-        this.bytes = bytes
-        block(this)
-    }
 }

--- a/src/commonMain/kotlin/content/Image.kt
+++ b/src/commonMain/kotlin/content/Image.kt
@@ -59,6 +59,55 @@ class Image private constructor(
             MediaType.WEBP
         )
 
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            block: Image.Builder.() -> Unit
+        ): Image {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return Image.Builder().apply(block).build()
+        }
+
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            path: String,
+            block: Image.Builder.() -> Unit = {}
+        ): Image {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return Image(Path(path), block)
+        }
+
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            path: Path,
+            block: Image.Builder.() -> Unit = {}
+        ): Image {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return Image {
+                this.path = path
+                block(this)
+            }
+        }
+
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            bytes: ByteArray,
+            block: Image.Builder.() -> Unit = {}
+        ): Image {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return Image {
+                this.bytes = bytes
+                block(this)
+            }
+        }
+
     }
 
     @OptIn(ExperimentalContracts::class)
@@ -77,53 +126,4 @@ class Image private constructor(
 
     override fun toString(): String = toPrettyJson()
 
-}
-
-@OptIn(ExperimentalContracts::class)
-fun Image(
-    block: Image.Builder.() -> Unit
-): Image {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-    }
-    return Image.Builder().apply(block).build()
-}
-
-@OptIn(ExperimentalContracts::class)
-fun Image(
-    path: String,
-    block: Image.Builder.() -> Unit = {}
-): Image {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-    }
-    return Image(Path(path), block)
-}
-
-@OptIn(ExperimentalContracts::class)
-fun Image(
-    path: Path,
-    block: Image.Builder.() -> Unit = {}
-): Image {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-    }
-    return Image {
-        this.path = path
-        block(this)
-    }
-}
-
-@OptIn(ExperimentalContracts::class)
-fun Image(
-    bytes: ByteArray,
-    block: Image.Builder.() -> Unit = {}
-): Image {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-    }
-    return Image {
-        this.bytes = bytes
-        block(this)
-    }
 }

--- a/src/commonMain/kotlin/content/Text.kt
+++ b/src/commonMain/kotlin/content/Text.kt
@@ -63,28 +63,32 @@ class Text private constructor(
         }.build()
     }
 
-}
+    companion object {
 
-@OptIn(ExperimentalContracts::class)
-fun Text(
-    block: Text.Builder.() -> Unit
-): Text {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-    }
-    return Text.Builder().apply(block).build()
-}
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            block: Text.Builder.() -> Unit
+        ): Text {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return Text.Builder().apply(block).build()
+        }
 
-@OptIn(ExperimentalContracts::class)
-fun Text(
-    text: String,
-    block: Text.Builder.() -> Unit = {}
-): Text {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            text: String,
+            block: Text.Builder.() -> Unit = {}
+        ): Text {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return Text {
+                this.text = text
+                block(this)
+            }
+        }
+
     }
-    return Text {
-        this.text = text
-        block(this)
-    }
+
 }

--- a/src/commonMain/kotlin/content/Tools.kt
+++ b/src/commonMain/kotlin/content/Tools.kt
@@ -77,16 +77,20 @@ class ToolUse private constructor(
         }.build()
     }
 
-}
+    companion object {
 
-@OptIn(ExperimentalContracts::class)
-fun ToolUse(
-    block: ToolUse.Builder.() -> Unit
-): ToolUse {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            block: ToolUse.Builder.() -> Unit
+        ): ToolUse {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return ToolUse.Builder().apply(block).build()
+        }
+
     }
-    return ToolUse.Builder().apply(block).build()
+
 }
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -159,14 +163,18 @@ class ToolResult private constructor(
         }.build()
     }
 
-}
+    companion object {
 
-@OptIn(ExperimentalContracts::class)
-inline fun ToolResult(
-    block: ToolResult.Builder.() -> Unit = {}
-): ToolResult {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        @OptIn(ExperimentalContracts::class)
+        inline operator fun invoke(
+            block: ToolResult.Builder.() -> Unit = {}
+        ): ToolResult {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return ToolResult.Builder().apply(block).build()
+        }
+
     }
-    return ToolResult.Builder().apply(block).build()
+
 }

--- a/src/commonMain/kotlin/content/WebFetchContent.kt
+++ b/src/commonMain/kotlin/content/WebFetchContent.kt
@@ -63,16 +63,20 @@ class WebFetchServerToolUse private constructor(
         }.build()
     }
 
-}
+    companion object {
 
-@OptIn(ExperimentalContracts::class)
-fun WebFetchServerToolUse(
-    block: WebFetchServerToolUse.Builder.() -> Unit
-): WebFetchServerToolUse {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            block: WebFetchServerToolUse.Builder.() -> Unit
+        ): WebFetchServerToolUse {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return WebFetchServerToolUse.Builder().apply(block).build()
+        }
+
     }
-    return WebFetchServerToolUse.Builder().apply(block).build()
+
 }
 
 @Serializable
@@ -164,14 +168,18 @@ class WebFetchToolResult private constructor(
         }.build()
     }
 
-}
+    companion object {
 
-@OptIn(ExperimentalContracts::class)
-fun WebFetchToolResult(
-    block: WebFetchToolResult.Builder.() -> Unit
-): WebFetchToolResult {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            block: WebFetchToolResult.Builder.() -> Unit
+        ): WebFetchToolResult {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return WebFetchToolResult.Builder().apply(block).build()
+        }
+
     }
-    return WebFetchToolResult.Builder().apply(block).build()
+
 }

--- a/src/commonMain/kotlin/content/WebSearchContent.kt
+++ b/src/commonMain/kotlin/content/WebSearchContent.kt
@@ -62,16 +62,20 @@ class WebSearchServerToolUse private constructor(
         }.build()
     }
 
-}
+    companion object {
 
-@OptIn(ExperimentalContracts::class)
-fun WebSearchServerToolUse(
-    block: WebSearchServerToolUse.Builder.() -> Unit
-): WebSearchServerToolUse {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            block: WebSearchServerToolUse.Builder.() -> Unit
+        ): WebSearchServerToolUse {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return WebSearchServerToolUse.Builder().apply(block).build()
+        }
+
     }
-    return WebSearchServerToolUse.Builder().apply(block).build()
+
 }
 
 @Serializable
@@ -149,16 +153,20 @@ class WebSearchToolResult private constructor(
         }.build()
     }
 
-}
+    companion object {
 
-@OptIn(ExperimentalContracts::class)
-fun WebSearchToolResult(
-    block: WebSearchToolResult.Builder.() -> Unit
-): WebSearchToolResult {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            block: WebSearchToolResult.Builder.() -> Unit
+        ): WebSearchToolResult {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return WebSearchToolResult.Builder().apply(block).build()
+        }
+
     }
-    return WebSearchToolResult.Builder().apply(block).build()
+
 }
 
 @Serializable

--- a/src/commonMain/kotlin/cost/Cost.kt
+++ b/src/commonMain/kotlin/cost/Cost.kt
@@ -117,7 +117,7 @@ class Cost private constructor(
             contract {
                 callsInPlace(block, InvocationKind.EXACTLY_ONCE)
             }
-            return Cost.Builder().also(block).build()
+            return Cost.Builder().apply(block).build()
         }
 
     }

--- a/src/commonMain/kotlin/cost/Cost.kt
+++ b/src/commonMain/kotlin/cost/Cost.kt
@@ -103,6 +103,7 @@ class Cost private constructor(
                     cacheReadInputTokens
 
     companion object {
+
         val ZERO = Cost(
             inputTokens = Money.ZERO,
             outputTokens = Money.ZERO,
@@ -110,6 +111,15 @@ class Cost private constructor(
             cache1hCreationInputTokens = Money.ZERO,
             cacheReadInputTokens = Money.ZERO
         )
+
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(block: Cost.Builder.() -> Unit): Cost {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return Cost.Builder().also(block).build()
+        }
+
     }
 
     override fun equals(other: Any?): Boolean {
@@ -138,12 +148,4 @@ class Cost private constructor(
 
     override fun toString(): String = toPrettyJson()
 
-}
-
-@OptIn(ExperimentalContracts::class)
-fun Cost(block: Cost.Builder.() -> Unit): Cost {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-    }
-    return Cost.Builder().also(block).build()
 }

--- a/src/commonMain/kotlin/message/Messages.kt
+++ b/src/commonMain/kotlin/message/Messages.kt
@@ -142,24 +142,28 @@ data class MessageRequest(
 
     override fun toString(): String = toPrettyJson()
 
-}
+    companion object {
 
-/**
- * Used only in tests
- */
-@OptIn(ExperimentalContracts::class)
-internal fun MessageRequest(
-    model: Model = Model.DEFAULT,
-    block: MessageRequest.Builder.() -> Unit
-): MessageRequest {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        /**
+         * Used only in tests
+         */
+        @OptIn(ExperimentalContracts::class)
+        internal operator fun invoke(
+            model: Model = Model.DEFAULT,
+            block: MessageRequest.Builder.() -> Unit
+        ): MessageRequest {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return MessageRequest.Builder().also {
+                it.model = model.id
+                it.maxTokens = model.maxOutput
+                block(it)
+            }.build()
+        }
+
     }
-    return MessageRequest.Builder().also {
-        it.model = model.id
-        it.maxTokens = model.maxOutput
-        block(it)
-    }.build()
+
 }
 
 @Serializable
@@ -194,16 +198,20 @@ class Message private constructor(
 
     override fun toString(): String = toPrettyJson()
 
-}
+    companion object {
 
-@OptIn(ExperimentalContracts::class)
-fun Message(
-    block: Message.Builder.() -> Unit = {}
-): Message {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(
+            block: Message.Builder.() -> Unit = {}
+        ): Message {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return Message.Builder().apply(block).build()
+        }
+
     }
-    return Message.Builder().apply(block).build()
+
 }
 
 @Serializable

--- a/src/commonMain/kotlin/tool/Bash.kt
+++ b/src/commonMain/kotlin/tool/Bash.kt
@@ -64,10 +64,10 @@ class Bash private constructor() : BuiltInTool<Bash.Input>(
             block: Input.Builder.() -> Unit
         ): Input = Input.Builder().apply(block).build()
 
+        operator fun invoke(
+            block: Bash.Builder.() -> Unit = {}
+        ): Bash = Bash.Builder().apply(block).build()
+
     }
 
 }
-
-fun Bash(
-    builder: Bash.Builder.() -> Unit = {}
-): Bash = Bash.Builder().apply(builder).build()

--- a/src/commonMain/kotlin/tool/Computer.kt
+++ b/src/commonMain/kotlin/tool/Computer.kt
@@ -113,10 +113,10 @@ class Computer private constructor(
             block: Input.Builder.() -> Unit
         ): Input = Input.Builder().apply(block).build()
 
+        operator fun invoke(
+            block: Computer.Builder.() -> Unit,
+        ): Computer = Computer.Builder().apply(block).build()
+
     }
 
 }
-
-fun Computer(
-    builder: Computer.Builder.() -> Unit,
-): Computer = Computer.Builder().apply(builder).build()

--- a/src/commonMain/kotlin/tool/TextEditor.kt
+++ b/src/commonMain/kotlin/tool/TextEditor.kt
@@ -102,10 +102,10 @@ class TextEditor private constructor(
             block: Input.Builder.() -> Unit
         ): Input = Input.Builder().apply(block).build()
 
+        operator fun invoke(
+            block: TextEditor.Builder.() -> Unit = {},
+        ): TextEditor = TextEditor.Builder().apply(block).build()
+
     }
 
 }
-
-fun TextEditor(
-    builder: TextEditor.Builder.() -> Unit = {},
-): TextEditor = TextEditor.Builder().apply(builder).build()

--- a/src/commonMain/kotlin/tool/Tools.kt
+++ b/src/commonMain/kotlin/tool/Tools.kt
@@ -211,12 +211,6 @@ internal val String.normalizedToolName: String
         .replace('$', '_')
         .take(64)
 
-fun Toolbox(block: Toolbox.Builder.() -> Unit): Toolbox {
-    val builder = Toolbox.Builder()
-    block(builder)
-    return builder.build()
-}
-
 class Toolbox private constructor(
     val tools: List<Tool>,
     private val handlerMap: Map<String, Handler>,
@@ -365,5 +359,15 @@ class Toolbox private constructor(
             result.toString()
         }
     )
+
+    companion object {
+
+        operator fun invoke(block: Toolbox.Builder.() -> Unit): Toolbox {
+            val builder = Toolbox.Builder()
+            block(builder)
+            return builder.build()
+        }
+
+    }
 
 }

--- a/src/commonMain/kotlin/tool/Tools.kt
+++ b/src/commonMain/kotlin/tool/Tools.kt
@@ -29,6 +29,9 @@ import com.xemantic.ai.tool.schema.ObjectSchema
 import com.xemantic.ai.tool.schema.generator.jsonSchemaOf
 import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 @Serializable(with = ToolSerializer::class)
 abstract class Tool {
@@ -362,7 +365,11 @@ class Toolbox private constructor(
 
     companion object {
 
+        @OptIn(ExperimentalContracts::class)
         operator fun invoke(block: Toolbox.Builder.() -> Unit): Toolbox {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
             val builder = Toolbox.Builder()
             block(builder)
             return builder.build()

--- a/src/commonMain/kotlin/tool/WebFetch.kt
+++ b/src/commonMain/kotlin/tool/WebFetch.kt
@@ -76,8 +76,12 @@ class WebFetch private constructor(
 
     }
 
-}
+    companion object {
 
-fun WebFetch(
-    builder: WebFetch.Builder.() -> Unit = {}
-): WebFetch = WebFetch.Builder().apply(builder).build()
+        operator fun invoke(
+            block: WebFetch.Builder.() -> Unit = {}
+        ): WebFetch = WebFetch.Builder().apply(block).build()
+
+    }
+
+}

--- a/src/commonMain/kotlin/tool/WebSearch.kt
+++ b/src/commonMain/kotlin/tool/WebSearch.kt
@@ -64,8 +64,12 @@ class WebSearch private constructor(
 
     }
 
-}
+    companion object {
 
-fun WebSearch(
-    builder: WebSearch.Builder.() -> Unit = {}
-): WebSearch = WebSearch.Builder().apply(builder).build()
+        operator fun invoke(
+            block: WebSearch.Builder.() -> Unit = {}
+        ): WebSearch = WebSearch.Builder().apply(block).build()
+
+    }
+
+}

--- a/src/commonMain/kotlin/usage/Usage.kt
+++ b/src/commonMain/kotlin/usage/Usage.kt
@@ -76,7 +76,7 @@ class Usage private constructor(
             contract {
                 callsInPlace(block, InvocationKind.EXACTLY_ONCE)
             }
-            return Usage.Builder().also(block).build()
+            return Usage.Builder().apply(block).build()
         }
 
     }
@@ -176,7 +176,7 @@ class CacheCreation private constructor(
             contract {
                 callsInPlace(block, InvocationKind.EXACTLY_ONCE)
             }
-            return CacheCreation.Builder().also(block).build()
+            return CacheCreation.Builder().apply(block).build()
         }
 
     }
@@ -239,7 +239,7 @@ class ServerToolUse private constructor(
             contract {
                 callsInPlace(block, InvocationKind.EXACTLY_ONCE)
             }
-            return ServerToolUse.Builder().also(block).build()
+            return ServerToolUse.Builder().apply(block).build()
         }
 
     }

--- a/src/commonMain/kotlin/usage/Usage.kt
+++ b/src/commonMain/kotlin/usage/Usage.kt
@@ -71,6 +71,14 @@ class Usage private constructor(
             cacheReadInputTokens = 0
         )
 
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(block: Usage.Builder.() -> Unit): Usage {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return Usage.Builder().also(block).build()
+        }
+
     }
 
     operator fun plus(usage: Usage): Usage = Usage(
@@ -108,14 +116,6 @@ class Usage private constructor(
 
     override fun toString(): String = toPrettyJson()
 
-}
-
-@OptIn(ExperimentalContracts::class)
-fun Usage(block: Usage.Builder.() -> Unit): Usage {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-    }
-    return Usage.Builder().also(block).build()
 }
 
 /**
@@ -171,16 +171,16 @@ class CacheCreation private constructor(
             ephemeral1hInputTokens = 0
         )
 
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(block: CacheCreation.Builder.() -> Unit): CacheCreation {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return CacheCreation.Builder().also(block).build()
+        }
+
     }
 
-}
-
-@OptIn(ExperimentalContracts::class)
-fun CacheCreation(block: CacheCreation.Builder.() -> Unit): CacheCreation {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-    }
-    return CacheCreation.Builder().also(block).build()
 }
 
 /**
@@ -234,14 +234,14 @@ class ServerToolUse private constructor(
             webFetchRequests = 0
         )
 
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(block: ServerToolUse.Builder.() -> Unit = {}): ServerToolUse {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return ServerToolUse.Builder().also(block).build()
+        }
+
     }
 
-}
-
-@OptIn(ExperimentalContracts::class)
-fun ServerToolUse(block: ServerToolUse.Builder.() -> Unit = {}): ServerToolUse {
-    contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
-    }
-    return ServerToolUse.Builder().also(block).build()
 }


### PR DESCRIPTION
Migrates all top-level `fun TypeName(block: TypeName.Builder.() -> Unit)` factory functions to `fun TypeName.Companion.invoke(block: TypeName.Builder.() -> Unit)` companion object operator functions.

Closes #131

Generated with [Claude Code](https://claude.ai/code)