### PR TITLE
chore: dependency + gradle wrapper bump, CLAUDE.md cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,136 +1,29 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file captures only what cannot be inferred from the codebase itself.
 
-## Common Development Commands
+## Rules for editing this file
 
-### Building
-```bash
-./gradlew build
-```
+Both developers and AI agents are expected to add entries as they encounter surprises.
+
+- **Add an entry** when you encounter something unexpected: a build quirk, a non-obvious constraint, a dependency gotcha, or any behavior that would surprise the next agent or developer.
+- **Add an entry** when a developer flags an anti-pattern produced by AI — describe the anti-pattern and the preferred alternative.
+- **Do not** add codebase overviews, directory listings, or anything discoverable by reading the source.
+- Keep entries concise: one line per lesson, grouped under a heading if a theme emerges.
+
+## Known gotchas
 
 ### Testing
-Set the `ANTHROPIC_API_KEY` environment variable before running tests:
-```bash
-export ANTHROPIC_API_KEY=your-api-key
-./gradlew test
-```
+- Most tests are live integration tests against Anthropic APIs and require `ANTHROPIC_API_KEY` in the environment; without it they fail rather than skip.
+- Tests default to Claude Haiku to keep API costs down — preserve that default when adding new tests unless a specific model is under test.
+- Tests can be flaky due to AI model variability; release builds intentionally skip tests for this reason, so don't gate releases on green test runs.
 
-Many tests are integration tests that call Anthropic APIs, so they require a valid API key.
+### Building
+- `./gradlew build -PjvmOnlyBuild=true` skips non-JVM targets for faster local iteration — useful when you don't need to verify multiplatform output.
 
-### JVM-only Build
-For faster iteration during development:
-```bash
-./gradlew build -PjvmOnlyBuild=true
-```
+### Adding new models
+- Verify pricing at anthropic.com/pricing before adding a `Model` enum entry — pricing isn't derivable from code and is the most common source of incorrect entries.
 
-### Single Test Execution
-```bash
-./gradlew :jvmTest --tests "SpecificTestClass"
-```
+## Anti-patterns to avoid
 
-### Publishing
-For releases:
-```bash
-./gradlew publishToSonatype
-```
-
-### Documentation Generation
-```bash
-./gradlew dokkaGeneratePublicationHtml
-```
-
-## Project Architecture
-
-This is a Kotlin Multiplatform project providing an unofficial SDK for Anthropic's Claude API. The project is structured as a single module with platform-specific source sets.
-
-### Source Structure
-- `src/commonMain/kotlin/`: Shared Kotlin code for all platforms
-- `src/jvmMain/kotlin/`: JVM-specific implementations
-- `src/jsMain/kotlin/`: JavaScript-specific implementations  
-- `src/nativeMain/kotlin/`: Native platform implementations
-- `src/commonTest/kotlin/`: Shared test code
-
-### Core Packages
-- `com.xemantic.ai.anthropic`: Main API client (`Anthropic` class)
-- `com.xemantic.ai.anthropic.message`: Message handling and request/response types
-- `com.xemantic.ai.anthropic.content`: Content types (text, images, tool uses)
-- `com.xemantic.ai.anthropic.tool`: Tool definition and execution framework
-- `com.xemantic.ai.anthropic.event`: Streaming event handling
-- `com.xemantic.ai.anthropic.cost`: Usage tracking and cost calculation
-- `com.xemantic.ai.anthropic.error`: Error handling and exception types
-
-### Key Design Patterns
-
-#### Tool System
-The SDK uses Kotlin's type system to provide type-safe tool definitions. Tools are defined using data classes with `@Serializable` annotations, and JSON schemas are automatically generated using the xemantic-ai-tool-schema library.
-
-#### Streaming Support
-The API supports both blocking message creation and streaming via Kotlin Flow. Streaming responses emit `Event` objects that can be filtered and processed.
-
-#### Cost Tracking
-Built-in cost calculation using the `CostCollector` class that tracks token usage and associated costs across API calls.
-
-#### Platform Abstraction
-Uses `expect`/`actual` declarations for platform-specific functionality like environment variable access.
-
-## Dependencies
-
-### Core Dependencies
-- **Ktor**: HTTP client and content negotiation
-- **kotlinx.serialization**: JSON serialization
-- **xemantic-ai-tool-schema**: JSON schema generation for tools
-- **xemantic-ai-money**: Money representation for cost calculation
-
-### Platform-Specific HTTP Clients
-- JVM: `ktor-client-java`
-- Native (Linux/Windows): `ktor-client-curl`
-- Native (macOS/iOS): `ktor-client-darwin`
-
-### Gradle Configuration
-- Uses version catalogs (`gradle/libs.versions.toml`)
-- Kotlin target version: 2.2
-- Java target version: 17
-- Progressive Kotlin compilation mode enabled
-- Power Assert plugin for enhanced test assertions
-
-## Testing Notes
-
-- Many tests are integration tests requiring `ANTHROPIC_API_KEY`
-- Tests default to Claude Haiku model to reduce API costs
-- Tests may be flaky due to AI model variability
-- Some native target tests are disabled on CI
-- Release builds skip tests to avoid flakiness during releases
-- Test timeout for JS tests: 60 seconds
-
-## Adding New Models
-
-When adding new models to the `Model` enum in `src/commonMain/kotlin/Models.kt`:
-- Always verify current pricing at anthropic.com/pricing
-- Update the `cost` field with accurate `inputTokens` and `outputTokens` values using the `dollarsPerMillion` extension (e.g., `"3".dollarsPerMillion`)
-- Verify `contextWindow`, `maxOutput`, and `messageBatchesApi` support from the official documentation
-- Add the new model enum entry following the existing pattern
-
-## Multiplatform Targets
-
-### Tier 1 (Fully Supported)
-- JVM
-- macOS (x64, ARM64)
-- iOS (ARM64, x64, Simulator ARM64)
-
-### Tier 2 (Best Effort)
-- Linux (x64, ARM64)  
-- Windows (x64)
-- watchOS, tvOS variants
-
-### JavaScript
-- Node.js and Browser targets supported
-- Karma + Chrome Headless for browser tests
-- Mocha for Node.js tests
-
-## Important Files
-
-- `src/commonMain/kotlin/Anthropic.kt`: Main API client
-- `docs/tool_use.md`: Comprehensive tool usage documentation
-- `gradle/libs.versions.toml`: Dependency version management
-- `build.gradle.kts`: Build configuration with multiplatform setup
+- Do not add content to this file that is already discoverable by reading the source or build scripts — that inflates context without adding signal, reducing AI agent task success rates (see [arxiv 2602.11988](https://arxiv.org/abs/2602.11988)).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,27 +3,27 @@ kotlinTarget = "2.3"
 javaTarget = "17"
 
 # jetbrains
-kotlin = "2.3.0"
+kotlin = "2.3.21"
 kotlinxCoroutines = "1.10.2"
 # don't upgrade these 2 until kotlin-2.3.10 is released with native linux compilaiton hang fix
-kotlinxSerialization = "1.10.0"
-ktor = "3.4.0"
+kotlinxSerialization = "1.11.0"
+ktor = "3.4.3"
 
 # xemantic
 xemanticKotlinCore = "0.6.4"
-xemanticKotlinTest = "1.17.2"
+xemanticKotlinTest = "1.17.5"
 xemanticAiToolSchema = "1.2.0"
 xemanticAiMoney = "0.2"
 xemanticAiFileMagic = "0.4.0"
 
 # logging
 slf4j = "2.0.17"
-logback = "1.5.25"
+logback = "1.5.32"
 
-versionsPlugin = "0.53.0"
-dokkaPlugin = "2.1.0"
+versionsPlugin = "0.54.0"
+dokkaPlugin = "2.2.0"
 mavenPublishPlugin = "0.36.0"
-jreleaserPlugin = "1.22.0"
+jreleaserPlugin = "1.23.0"
 xemanticConventionsPlugin = "0.6.8"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,7 +16,7 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Bump Kotlin (2.3.0 → 2.3.21), kotlinx.serialization (1.10.0 → 1.11.0), Ktor (3.4.0 → 3.4.3), xemantic-kotlin-test, logback, and several Gradle plugins (versions, dokka, jreleaser).
- Upgrade Gradle wrapper 9.3.0 → 9.4.1.
- Trim `CLAUDE.md` to project-specific gotchas and editing rules; drop the codebase overview that was already discoverable from source.

## Test plan
- [ ] `./gradlew build -PjvmOnlyBuild=true` passes locally
- [ ] CI green on multiplatform targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)