### PR TITLE
feat: add Claude Opus 4.7 model and correct 1M context window

### DIFF
--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -1095,6 +1095,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-path-inside@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
 is-plain-obj@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
@@ -1361,10 +1366,10 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.6"
 
-mocha@11.7.2:
-  version "11.7.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-11.7.2.tgz#3c0079fe5cc2f8ea86d99124debcc42bb1ab22b5"
-  integrity sha512-lkqVJPmqqG/w5jmmFtiRvtA2jkDyNVUcefFJKb2uyX4dekk8Okgqop3cgbFiaIvj8uCRJVTP5x9dfxGyXm2jvQ==
+mocha@11.7.5:
+  version "11.7.5"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-11.7.5.tgz#58f5bbfa5e0211ce7e5ee6128107cefc2515a627"
+  integrity sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==
   dependencies:
     browser-stdout "^1.3.1"
     chokidar "^4.0.1"
@@ -1374,6 +1379,7 @@ mocha@11.7.2:
     find-up "^5.0.0"
     glob "^10.4.5"
     he "^1.2.0"
+    is-path-inside "^3.0.3"
     js-yaml "^4.1.0"
     log-symbols "^4.1.0"
     minimatch "^9.0.5"

--- a/src/commonMain/kotlin/Models.kt
+++ b/src/commonMain/kotlin/Models.kt
@@ -55,9 +55,21 @@ enum class Model(
     override val cacheMinTokens: Int
 ) : AnthropicModel {
 
+    CLAUDE_OPUS_4_7(
+        id = "claude-opus-4-7",
+        contextWindow = 1000000,
+        maxOutput = 128000,
+        messageBatchesApi = true,
+        cost = Cost {
+            inputTokens = "5".dollarsPerMillion
+            outputTokens = "25".dollarsPerMillion
+        },
+        cacheMinTokens = 1024
+    ),
+
     CLAUDE_SONNET_4_6(
         id = "claude-sonnet-4-6",
-        contextWindow = 200000,
+        contextWindow = 1000000,
         maxOutput = 64000,
         messageBatchesApi = true,
         cost = Cost {
@@ -81,7 +93,7 @@ enum class Model(
 
     CLAUDE_OPUS_4_6(
         id = "claude-opus-4-6",
-        contextWindow = 200000,
+        contextWindow = 1000000,
         maxOutput = 128000,
         messageBatchesApi = true,
         cost = Cost {


### PR DESCRIPTION
## Summary
- Add `CLAUDE_OPUS_4_7` enum entry — id `claude-opus-4-7`, 1M context, 128k max output, \$5/\$25 per MTok input/output, 1024 cacheMinTokens (verified against [Anthropic pricing docs](https://platform.claude.com/docs/en/about-claude/pricing) and [models overview](https://platform.claude.com/docs/en/about-claude/models/overview))
- Correct `CLAUDE_OPUS_4_6` and `CLAUDE_SONNET_4_6` `contextWindow` from `200000` to `1000000` — these models ship with the 1M-token context window enabled by default per the [context windows docs](https://platform.claude.com/docs/en/build-with-claude/context-windows) ("Claude Opus 4.7, Claude Opus 4.6, and Claude Sonnet 4.6 have a 1M-token context window")
- `Model.DEFAULT` left as `CLAUDE_SONNET_4_6` (cost-balanced default; switching to Opus would 5x input cost for callers that don't pin a model)

## Test plan
- [x] `./gradlew compileKotlinJvm -PjvmOnlyBuild=true` passes
- [ ] Smoke-test a request against `claude-opus-4-7` once API key is available
- [ ] Confirm no downstream consumer relies on the previous 200k value as a hard limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)