### PR TITLE
feat: allow customizing HTTP client via httpClientConfig

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ Both developers and AI agents are expected to add entries as they encounter surp
 - Most tests are live integration tests against Anthropic APIs and require `ANTHROPIC_API_KEY` in the environment; without it they fail rather than skip.
 - Tests default to Claude Haiku to keep API costs down — preserve that default when adding new tests unless a specific model is under test.
 - Tests can be flaky due to AI model variability; release builds intentionally skip tests for this reason, so don't gate releases on green test runs.
+- Tests must retain `// given`, `// when`, `// then` comment structure — AI agents tend to omit these.
+
+### Auto mode
+- Do not commit when auto mode is active — wait for an explicit commit instruction from the user.
 
 ### Building
 - `./gradlew build -PjvmOnlyBuild=true` skips non-JVM targets for faster local iteration — useful when you don't need to verify multiplatform output.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,30 @@ fun main() = runBlocking {
 }
 ```
 
+### Customizing the HTTP client
+
+Under the hood the SDK uses [ktor](https://ktor.io/)'s `HttpClient`. The `httpClientConfig` block on `Anthropic.Config` is applied last, so it can install additional plugins or layer extra defaults on top of the SDK's own configuration. This is the place to add custom headers (for example `Authorization: Bearer …` when routing through a gateway), tweak timeouts, or attach a custom logger.
+
+```kotlin
+val anthropic = Anthropic {
+    httpClientConfig = {
+        install(HttpTimeout) {
+            requestTimeoutMillis = 60_000
+        }
+        defaultRequest {
+            header("Authorization", "Bearer $gatewayToken")
+            header("X-Tenant-Id", tenantId)
+        }
+    }
+}
+```
+
+Notes:
+
+- Multiple `defaultRequest { }` blocks accumulate in ktor 3.x, so headers added here are appended to the SDK's defaults (`x-api-key`, `anthropic-version`, etc.) rather than replacing them.
+- `apiKey` is still required at construction time and the SDK will always send `x-api-key`. If your gateway only accepts a Bearer token, supply a placeholder `apiKey` and have the gateway strip the unwanted header.
+- For proxies and self-hosted gateways, override the base URL via `apiBase` instead of trying to rewrite it from `httpClientConfig`.
+
 ### Using tools
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Notes:
 - Multiple `defaultRequest { }` blocks accumulate in ktor 3.x, so headers added here are appended to the SDK's defaults (`x-api-key`, `anthropic-version`, etc.) rather than replacing them.
 - `apiKey` is still required at construction time and the SDK will always send `x-api-key`. If your gateway only accepts a Bearer token, supply a placeholder `apiKey` and have the gateway strip the unwanted header.
 - For proxies and self-hosted gateways, override the base URL via `apiBase` instead of trying to rewrite it from `httpClientConfig`.
+- Avoid re-installing plugins already set up by the SDK (`SSE`, `ContentNegotiation`, `Logging`, `HttpRequestRetry`) — ktor will fail at install time or silently override SDK behavior.
 
 ### Using tools
 

--- a/src/commonMain/kotlin/Anthropic.kt
+++ b/src/commonMain/kotlin/Anthropic.kt
@@ -122,6 +122,18 @@ class Anthropic internal constructor(
         var modelMap: MutableMap<String, AnthropicModel> =
             Model.entries.associateBy { it.id }.toMutableMap()
 
+        /**
+         * Additional configuration applied to the underlying ktor [HttpClient]
+         * after all SDK defaults. Use it to install custom plugins (e.g. `HttpTimeout`)
+         * or to add a [defaultRequest] block with extra headers, such as
+         * `Authorization: Bearer ...` when routing through a gateway.
+         *
+         * Multiple [defaultRequest] blocks accumulate in ktor 3.x, so SDK-set
+         * headers (`x-api-key`, `anthropic-version`, ...) are preserved rather
+         * than replaced. Avoid re-installing plugins the SDK already configures
+         * (`SSE`, `ContentNegotiation`, `Logging`, `HttpRequestRetry`) — doing
+         * so will fail at install time or silently override SDK behavior.
+         */
         var httpClientConfig: HttpClientConfig<*>.() -> Unit = {}
 
         operator fun Beta.unaryPlus() {

--- a/src/commonMain/kotlin/Anthropic.kt
+++ b/src/commonMain/kotlin/Anthropic.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Kazimierz Pogoda / Xemantic
+ * Copyright 2024-2026 Xemantic contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,8 @@ fun Anthropic(
         defaultTools = config.defaultTools,
         directBrowserAccess = config.directBrowserAccess,
         logLevel = if (config.logHttp) LogLevel.ALL else LogLevel.NONE,
-        modelMap = config.modelMap
+        modelMap = config.modelMap,
+        httpClientConfig = config.httpClientConfig
     )
 } // TODO this can be a second constructor, then toolMap can be private
 
@@ -93,7 +94,8 @@ class Anthropic internal constructor(
     val defaultTools: List<Tool>?,
     val directBrowserAccess: Boolean,
     val logLevel: LogLevel,
-    private val modelMap: Map<String, AnthropicModel>
+    private val modelMap: Map<String, AnthropicModel>,
+    httpClientConfig: HttpClientConfig<*>.() -> Unit
 ) {
 
     private val costCollector = CostCollector()
@@ -119,6 +121,8 @@ class Anthropic internal constructor(
 
         var modelMap: MutableMap<String, AnthropicModel> =
             Model.entries.associateBy { it.id }.toMutableMap()
+
+        var httpClientConfig: HttpClientConfig<*>.() -> Unit = {}
 
         operator fun Beta.unaryPlus() {
             anthropicBeta += this.id
@@ -191,6 +195,7 @@ class Anthropic internal constructor(
             }
         }
 
+        httpClientConfig()
     }
 
     inner class Messages {

--- a/src/commonTest/kotlin/AnthropicTest.kt
+++ b/src/commonTest/kotlin/AnthropicTest.kt
@@ -37,9 +37,9 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
-private object HttpClientConfigTestAbort : RuntimeException()
-
 class AnthropicTest {
+
+    private object HttpClientConfigTestAbort : RuntimeException()
 
     @Test
     fun `should create Anthropic instance with 0 Usage and Cost`() {

--- a/src/commonTest/kotlin/AnthropicTest.kt
+++ b/src/commonTest/kotlin/AnthropicTest.kt
@@ -29,10 +29,15 @@ import com.xemantic.kotlin.test.assert
 import com.xemantic.kotlin.test.be
 import com.xemantic.kotlin.test.have
 import com.xemantic.kotlin.test.should
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.api.*
+import io.ktor.client.request.*
 import io.ktor.http.*
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+
+private object HttpClientConfigTestAbort : RuntimeException()
 
 class AnthropicTest {
 
@@ -229,6 +234,59 @@ class AnthropicTest {
                 have(inputTokens == 15)
                 have(outputTokens > 0)
             }
+        }
+    }
+
+    @Test
+    fun `should invoke httpClientConfig when constructing Anthropic`() {
+        // given
+        var configInvoked = false
+
+        // when
+        Anthropic {
+            apiKey = "test-key"
+            httpClientConfig = {
+                configInvoked = true
+            }
+        }
+
+        // then
+        assert(configInvoked)
+    }
+
+    @Test
+    fun `should allow customizing HTTP request headers via httpClientConfig`() = runTest {
+        // given
+        val capturedHeaders = mutableMapOf<String, List<String>>()
+        val captureAndAbort = createClientPlugin("CaptureAndAbort") {
+            onRequest { request, _ ->
+                request.headers.entries().forEach { (key, values) ->
+                    capturedHeaders[key] = values
+                }
+                throw HttpClientConfigTestAbort
+            }
+        }
+        val anthropic = Anthropic {
+            apiKey = "test-api-key"
+            httpClientConfig = {
+                install(captureAndAbort)
+                defaultRequest {
+                    header("Authorization", "Bearer custom-token")
+                    header("X-Custom-Header", "custom-value")
+                }
+            }
+        }
+
+        // when
+        assertFailsWith<HttpClientConfigTestAbort> {
+            anthropic.messages.create { +"Hi" }
+        }
+
+        // then
+        capturedHeaders should {
+            have(get("x-api-key") == listOf("test-api-key"))
+            have(get("Authorization") == listOf("Bearer custom-token"))
+            have(get("X-Custom-Header") == listOf("custom-value"))
         }
     }
 


### PR DESCRIPTION
Expose `httpClientConfig` on `Anthropic.Config` so callers can install extra ktor plugins or layer additional `defaultRequest` blocks (e.g. `Authorization: Bearer …` for gateway routing) on top of the SDK's own configuration. Adds tests covering wiring and header customization, plus README documentation and CLAUDE.md gotchas.