### PR TITLE
feat: add ToolChoice.None support

### DIFF
--- a/src/commonMain/kotlin/tool/Tools.kt
+++ b/src/commonMain/kotlin/tool/Tools.kt
@@ -116,19 +116,19 @@ inline fun <reified T> Tool(
 
 }
 
-interface ParallelToolUseControl {
-    val disableParallelToolUse: Boolean?
-}
-
 @Serializable
 sealed class ToolChoice {
+
+    interface ParallelControl {
+        val disableParallelToolUse: Boolean?
+    }
 
     @Serializable
     @SerialName("auto")
     class Auto private constructor(
         @SerialName("disable_parallel_tool_use")
         override val disableParallelToolUse: Boolean? = null
-    ) : ToolChoice(), ParallelToolUseControl {
+    ) : ToolChoice(), ParallelControl {
 
         class Builder {
 
@@ -147,7 +147,7 @@ sealed class ToolChoice {
     class Any private constructor(
         @SerialName("disable_parallel_tool_use")
         override val disableParallelToolUse: Boolean? = null
-    ) : ToolChoice(), ParallelToolUseControl {
+    ) : ToolChoice(), ParallelControl {
 
         class Builder {
 
@@ -167,7 +167,7 @@ sealed class ToolChoice {
         val name: String,
         @SerialName("disable_parallel_tool_use")
         override val disableParallelToolUse: Boolean? = null
-    ) : ToolChoice(), ParallelToolUseControl {
+    ) : ToolChoice(), ParallelControl {
 
         class Builder {
 

--- a/src/commonMain/kotlin/tool/Tools.kt
+++ b/src/commonMain/kotlin/tool/Tools.kt
@@ -181,6 +181,12 @@ sealed class ToolChoice {
 
     }
 
+    @Serializable
+    @SerialName("none")
+    data object None : ToolChoice() {
+        override val disableParallelToolUse: Boolean? = null
+    }
+
     companion object {
 
         fun Auto(

--- a/src/commonMain/kotlin/tool/Tools.kt
+++ b/src/commonMain/kotlin/tool/Tools.kt
@@ -116,17 +116,19 @@ inline fun <reified T> Tool(
 
 }
 
+interface ParallelToolUseControl {
+    val disableParallelToolUse: Boolean?
+}
+
 @Serializable
 sealed class ToolChoice {
-
-    abstract val disableParallelToolUse: Boolean?
 
     @Serializable
     @SerialName("auto")
     class Auto private constructor(
         @SerialName("disable_parallel_tool_use")
         override val disableParallelToolUse: Boolean? = null
-    ) : ToolChoice() {
+    ) : ToolChoice(), ParallelToolUseControl {
 
         class Builder {
 
@@ -145,7 +147,7 @@ sealed class ToolChoice {
     class Any private constructor(
         @SerialName("disable_parallel_tool_use")
         override val disableParallelToolUse: Boolean? = null
-    ) : ToolChoice() {
+    ) : ToolChoice(), ParallelToolUseControl {
 
         class Builder {
 
@@ -165,7 +167,7 @@ sealed class ToolChoice {
         val name: String,
         @SerialName("disable_parallel_tool_use")
         override val disableParallelToolUse: Boolean? = null
-    ) : ToolChoice() {
+    ) : ToolChoice(), ParallelToolUseControl {
 
         class Builder {
 
@@ -183,9 +185,7 @@ sealed class ToolChoice {
 
     @Serializable
     @SerialName("none")
-    data object None : ToolChoice() {
-        override val disableParallelToolUse: Boolean? = null
-    }
+    data object None : ToolChoice()
 
     companion object {
 

--- a/src/commonTest/kotlin/tool/ToolChoiceSerializationTest.kt
+++ b/src/commonTest/kotlin/tool/ToolChoiceSerializationTest.kt
@@ -98,4 +98,20 @@ class ToolChoiceSerializationTest {
 
     }
 
+    @Test
+    fun `should serialize ToolChoice None`() {
+
+        // given
+        // when
+        val result = ToolChoice.None.encodeToString()
+
+        // then
+        result sameAsJson """
+            {
+              "type": "none"
+            }
+        """.trimIndent()
+
+    }
+
 }


### PR DESCRIPTION
Adds the missing `ToolChoice.None` variant which serializes to `{"type":"none"}`, preventing the model from calling any tools.

Closes #141

Generated with [Claude Code](https://claude.ai/code)