### PR TITLE
feat: support Anthropic-compatible providers via configurable baseUrl and auth headers

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -15,3 +15,4 @@ jobs:
       gradle_args: -PjvmOnlyBuild=false -PrunMoonshotTests=true build publishToMavenCentral --no-configuration-cache
       maven_central: true
       anthropic: true
+      moonshot: true

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -12,6 +12,6 @@ jobs:
     secrets:
       inherit
     with:
-      gradle_args: -PjvmOnlyBuild=false build publishToMavenCentral --no-configuration-cache
+      gradle_args: -PjvmOnlyBuild=false -PrunMoonshotTests=true build publishToMavenCentral --no-configuration-cache
       maven_central: true
       anthropic: true

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -10,5 +10,5 @@ jobs:
     secrets:
       inherit
     with:
-      gradle_args: build -PjvmOnlyBuild=true
+      gradle_args: build -PjvmOnlyBuild=true -PrunMoonshotTests=true
       anthropic: true

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -12,3 +12,4 @@ jobs:
     with:
       gradle_args: build -PjvmOnlyBuild=true -PrunMoonshotTests=true
       anthropic: true
+      moonshot: true

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,7 +21,7 @@ jobs:
     secrets:
       inherit
     with:
-      gradle_args: -Pversion=${{ needs.extract_version.outputs.version }} -PjvmOnlyBuild=false build publishToMavenCentral jreleaserAnnounce --no-configuration-cache
+      gradle_args: -Pversion=${{ needs.extract_version.outputs.version }} -PjvmOnlyBuild=false -PrunMoonshotTests=true build publishToMavenCentral jreleaserAnnounce --no-configuration-cache
       maven_central: true
       jreleaser: true
       anthropic: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Both developers and AI agents are expected to add entries as they encounter surp
 - Tests default to Claude Haiku to keep API costs down — preserve that default when adding new tests unless a specific model is under test.
 - Tests can be flaky due to AI model variability; release builds intentionally skip tests for this reason, so don't gate releases on green test runs.
 - Tests must retain `// given`, `// when`, `// then` comment structure — AI agents tend to omit these.
+- Test-name filter patterns are not portable across targets. JVM's `filter.excludeTestsMatching("ClassName")` matches by simple class name, but Kotlin/Native's `--ktest_negative_gradle_filter=...` and Kotlin/JS's `filter.excludeTestsMatching(...)` match against the fully-qualified test descriptor — bare class names silently fail to match. Use `*ClassName*` (or fully-qualified `pkg.ClassName`) for native and JS.
 
 ### Auto mode
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,10 +75,24 @@ val skipMoonshotTests = !(runMoonshotTests?.toBoolean() ?: false)
 
 val anthropicApiKey: String? = System.getenv("ANTHROPIC_API_KEY")
 
+val moonshotEnvVars = listOf(
+    "MOONSHOT_API_BASE_URL",
+    "MOONSHOT_DEFAULT_MODEL",
+    "MOONSHOT_API_KEY"
+).associateWith { System.getenv(it) }
+
 val moonshotTests = listOf("MoonshotTest")
 
 tasks.withType<KotlinJvmTest>().configureEach {
     environment("GRADLE_ROOT_DIR", gradleRootDir)
+    if (anthropicApiKey != null) {
+        environment("ANTHROPIC_API_KEY", anthropicApiKey)
+    }
+    moonshotEnvVars.forEach { (name, value) ->
+        if (value != null) {
+            environment(name, value)
+        }
+    }
     if (skipMoonshotTests) {
         filter {
             moonshotTests.forEach {
@@ -93,6 +107,11 @@ tasks.withType<KotlinJsTest>().configureEach {
     if (anthropicApiKey != null) {
         environment("ANTHROPIC_API_KEY", anthropicApiKey)
     }
+    moonshotEnvVars.forEach { (name, value) ->
+        if (value != null) {
+            environment(name, value)
+        }
+    }
     if (skipMoonshotTests) {
         moonshotTests.forEach {
             filter.excludeTestsMatching("*$it*")
@@ -106,6 +125,12 @@ tasks.withType<KotlinNativeTest>().configureEach {
     if (anthropicApiKey != null) {
         environment("ANTHROPIC_API_KEY", anthropicApiKey)
         environment("SIMCTL_CHILD_ANTHROPIC_API_KEY", anthropicApiKey)
+    }
+    moonshotEnvVars.forEach { (name, value) ->
+        if (value != null) {
+            environment(name, value)
+            environment("SIMCTL_CHILD_$name", value)
+        }
     }
     if (skipMoonshotTests) {
         moonshotTests.forEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,16 +70,33 @@ val skipTests = isReleaseBuild
 
 val gradleRootDir: String = rootDir.absolutePath
 
+val runMoonshotTests: String? by project
+val skipMoonshotTests = !(runMoonshotTests?.toBoolean() ?: false)
+
 val anthropicApiKey: String? = System.getenv("ANTHROPIC_API_KEY")
+
+val moonshotTests = listOf("MoonshotTest")
 
 tasks.withType<KotlinJvmTest>().configureEach {
     environment("GRADLE_ROOT_DIR", gradleRootDir)
+    if (skipMoonshotTests) {
+        filter {
+            moonshotTests.forEach {
+                excludeTestsMatching(it)
+            }
+        }
+    }
 }
 
 tasks.withType<KotlinJsTest>().configureEach {
     environment("GRADLE_ROOT_DIR", gradleRootDir)
     if (anthropicApiKey != null) {
         environment("ANTHROPIC_API_KEY", anthropicApiKey)
+    }
+    if (skipMoonshotTests) {
+        moonshotTests.forEach {
+            filter.excludeTestsMatching("*$it*")
+        }
     }
 }
 
@@ -89,6 +106,11 @@ tasks.withType<KotlinNativeTest>().configureEach {
     if (anthropicApiKey != null) {
         environment("ANTHROPIC_API_KEY", anthropicApiKey)
         environment("SIMCTL_CHILD_ANTHROPIC_API_KEY", anthropicApiKey)
+    }
+    if (skipMoonshotTests) {
+        moonshotTests.forEach {
+            args += "--ktest_negative_gradle_filter=*$it*"
+        }
     }
 }
 
@@ -158,7 +180,6 @@ kotlin {
 
         // native, see https://kotlinlang.org/docs/native-target-support.html
         // tier 1
-        macosX64()
         macosArm64()
         iosSimulatorArm64()
         iosX64()
@@ -168,11 +189,9 @@ kotlin {
         linuxX64()
         linuxArm64()
         watchosSimulatorArm64()
-        watchosX64()
         watchosArm32()
         watchosArm64()
         tvosSimulatorArm64()
-        tvosX64()
         tvosArm64()
 
 //  // tier 3

--- a/src/commonMain/kotlin/Anthropic.kt
+++ b/src/commonMain/kotlin/Anthropic.kt
@@ -41,7 +41,7 @@ import kotlinx.coroutines.flow.mapNotNull
 /**
  * The default Anthropic API base.
  */
-const val ANTHROPIC_API_BASE: String = "https://api.anthropic.com/"
+const val ANTHROPIC_API_BASE_URL: String = "https://api.anthropic.com/"
 
 /**
  * The default version to be passed to the `anthropic-version` HTTP header of each API request.
@@ -70,12 +70,14 @@ fun Anthropic(
         apiKey = apiKey,
         anthropicVersion = config.anthropicVersion,
         anthropicBeta = if (config.anthropicBeta.isEmpty()) null else config.anthropicBeta.joinToString(","),
-        apiBase = config.apiBase,
+        baseUrl = config.baseUrl,
         defaultModel = config.defaultModel,
         defaultMaxTokens = config.defaultMaxTokens,
         defaultTools = config.defaultTools,
         directBrowserAccess = config.directBrowserAccess,
         logLevel = if (config.logHttp) LogLevel.ALL else LogLevel.NONE,
+        useXApiKeyHeader = config.useXApiKeyHeader,
+        useAuthorizationBearerHeader = config.useAuthorizationBearerHeader,
         httpClientConfig = config.httpClientConfig
     )
 } // TODO this can be a second constructor, then toolMap can be private
@@ -84,12 +86,14 @@ class Anthropic internal constructor(
     val apiKey: String,
     val anthropicVersion: String,
     val anthropicBeta: String?,
-    val apiBase: String,
+    val baseUrl: String,
     val defaultModel: String,
     val defaultMaxTokens: Int,
     val defaultTools: List<Tool>?,
     val directBrowserAccess: Boolean,
     val logLevel: LogLevel,
+    val useXApiKeyHeader: Boolean,
+    var useAuthorizationBearerHeader: Boolean,
     httpClientConfig: HttpClientConfig<*>.() -> Unit
 ) {
 
@@ -97,7 +101,7 @@ class Anthropic internal constructor(
         var apiKey: String? = null
         var anthropicVersion: String = DEFAULT_ANTHROPIC_VERSION
         var anthropicBeta: List<String> = emptyList()
-        var apiBase: String = ANTHROPIC_API_BASE
+        var baseUrl: String = ANTHROPIC_API_BASE_URL
         var defaultModel: String = Model.DEFAULT.id
         var defaultMaxTokens: Int = Model.DEFAULT.maxOutput
 
@@ -114,6 +118,10 @@ class Anthropic internal constructor(
 
         var directBrowserAccess: Boolean = false
         var logHttp: Boolean = false
+
+        var useXApiKeyHeader: Boolean = true
+
+        var useAuthorizationBearerHeader: Boolean = false
 
         /**
          * Additional configuration applied to the underlying ktor [HttpClient]
@@ -189,8 +197,13 @@ class Anthropic internal constructor(
         }
 
         defaultRequest {
-            url(apiBase)
-            header("x-api-key", apiKey)
+            url(baseUrl)
+            if (useXApiKeyHeader) {
+                header("x-api-key", apiKey)
+            }
+            if (useAuthorizationBearerHeader) {
+                header(HttpHeaders.Authorization, "Bearer $apiKey")
+            }
             header("anthropic-version", anthropicVersion)
             if (anthropicBeta != null) {
                 header("anthropic-beta", anthropicBeta)

--- a/src/commonMain/kotlin/Anthropic.kt
+++ b/src/commonMain/kotlin/Anthropic.kt
@@ -93,7 +93,7 @@ class Anthropic internal constructor(
     val directBrowserAccess: Boolean,
     val logLevel: LogLevel,
     val useXApiKeyHeader: Boolean,
-    var useAuthorizationBearerHeader: Boolean,
+    val useAuthorizationBearerHeader: Boolean,
     httpClientConfig: HttpClientConfig<*>.() -> Unit
 ) {
 

--- a/src/commonTest/kotlin/AnthropicTest.kt
+++ b/src/commonTest/kotlin/AnthropicTest.kt
@@ -39,7 +39,7 @@ import kotlin.test.assertFailsWith
 
 class AnthropicTest {
 
-    private object HttpClientConfigTestAbort : RuntimeException()
+    private class HttpClientConfigTestAbort : RuntimeException()
 
     @Test
     fun `should receive an introduction from Claude`() = runTest {
@@ -248,7 +248,7 @@ class AnthropicTest {
                 request.headers.entries().forEach { (key, values) ->
                     capturedHeaders[key] = values
                 }
-                throw HttpClientConfigTestAbort
+                throw HttpClientConfigTestAbort()
             }
         }
         val anthropic = Anthropic {

--- a/src/commonTest/kotlin/MoonshotTest.kt
+++ b/src/commonTest/kotlin/MoonshotTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024-2026 Xemantic contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.ai.anthropic
+
+import com.xemantic.ai.anthropic.content.Text
+import com.xemantic.ai.anthropic.message.Role
+import com.xemantic.ai.anthropic.message.StopReason
+import com.xemantic.ai.anthropic.test.env
+import com.xemantic.kotlin.test.be
+import com.xemantic.kotlin.test.have
+import com.xemantic.kotlin.test.should
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class MoonshotTest {
+
+    @Test
+    fun `should receive an introduction from Kimi`() = runTest {
+        // given
+        val anthropic = Anthropic {
+            baseUrl = env["MOONSHOT_API_BASE_URL"]
+            defaultModel = env["MOONSHOT_DEFAULT_MODEL"]
+            apiKey = env["MOONSHOT_API_KEY"]
+            useXApiKeyHeader = false
+            useAuthorizationBearerHeader = true
+        }
+
+        // when
+        val response = anthropic.messages.create {
+            +"Hello World! What's your name?"
+        }
+
+        // then
+        response should {
+            have(role == Role.ASSISTANT)
+            have("Kimi" in model)
+            have(stopReason == StopReason.END_TURN)
+            have(content.size == 1)
+            content[0] should {
+                be<Text>()
+                have("Kimi" in text)
+            }
+            have(stopSequence == "<|im_end|>")
+            usage should {
+                have(inputTokens == 33)
+                have(outputTokens > 0)
+            }
+        }
+    }
+
+}

--- a/src/commonTest/kotlin/test/TestSupport.kt
+++ b/src/commonTest/kotlin/test/TestSupport.kt
@@ -18,6 +18,7 @@ package com.xemantic.ai.anthropic.test
 
 import com.xemantic.ai.anthropic.Anthropic
 import com.xemantic.ai.anthropic.Model
+import com.xemantic.kotlin.test.getEnv
 import com.xemantic.kotlin.test.gradleRootDir
 import com.xemantic.kotlin.test.isBrowserPlatform
 import io.ktor.client.*
@@ -51,3 +52,15 @@ suspend fun fetchText(
 suspend fun fetchSkillText() = fetchText(
     "https://raw.githubusercontent.com/anthropics/skills/main/skills/skill-creator/SKILL.md"
 )
+
+val env = Env()
+
+class Env {
+
+    operator fun get(
+        key: String
+    ): String = requireNotNull(getEnv(key)) {
+        "No such environment variable: $key"
+    }
+
+}

--- a/src/wasmJsMain/kotlin/WasmJsAnthropic.kt
+++ b/src/wasmJsMain/kotlin/WasmJsAnthropic.kt
@@ -21,5 +21,5 @@ actual val envApiKey: String?
 actual val missingApiKeyMessage: String
     get() = "apiKey is missing, it has to be provided as a parameter."
 
-@OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
+@OptIn(ExperimentalWasmJsInterop::class)
 private fun getenv(name: String): String? = js("process.env[name]")


### PR DESCRIPTION
## Summary
- Rename `apiBase` → `baseUrl` and `ANTHROPIC_API_BASE` → `ANTHROPIC_API_BASE_URL` (breaking).
- Add `useXApiKeyHeader` (default `true`) and `useAuthorizationBearerHeader` (default `false`) so the SDK can target Anthropic-compatible providers — e.g. Moonshot/Kimi, which require `Authorization: Bearer …` instead of `x-api-key`.
- Add `MoonshotTest` as an opt-in integration test (skipped by default; enabled in CI via `-PrunMoonshotTests=true`). Gradle plumbing wires the same opt-in across JVM, Kotlin/JS, and Kotlin/Native test tasks.
- Drop deprecated Kotlin/Native targets `macosX64`, `watchosX64`, `tvosX64`.
- CLAUDE.md note: test-name filter patterns are not portable across targets — bare class names silently fail to match on Kotlin/Native and Kotlin/JS; use `*ClassName*`.
- Minor: convert `HttpClientConfigTestAbort` from `object` to `class` so each throw produces a fresh stack; tidy a `WasmJsAnthropic` `OptIn` import; add an `Env` helper in test support.

## Test plan
- [ ] `./gradlew build -PjvmOnlyBuild=true` (default — `MoonshotTest` skipped)
- [ ] CI run with `-PrunMoonshotTests=true` exercises `MoonshotTest` against Moonshot/Kimi (requires `MOONSHOT_API_BASE_URL`, `MOONSHOT_DEFAULT_MODEL`, `MOONSHOT_API_KEY` secrets)
- [ ] Verify existing Anthropic integration tests still pass with the renamed `baseUrl` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)