### PR TITLE
test: skip MoonshotTest on browser platforms

### DIFF
--- a/src/commonTest/kotlin/MoonshotTest.kt
+++ b/src/commonTest/kotlin/MoonshotTest.kt
@@ -22,6 +22,7 @@ import com.xemantic.ai.anthropic.message.StopReason
 import com.xemantic.ai.anthropic.test.env
 import com.xemantic.kotlin.test.be
 import com.xemantic.kotlin.test.have
+import com.xemantic.kotlin.test.isBrowserPlatform
 import com.xemantic.kotlin.test.should
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -30,6 +31,7 @@ class MoonshotTest {
 
     @Test
     fun `should receive an introduction from Kimi`() = runTest {
+        if (isBrowserPlatform) return@runTest // our test Moonshot API server depends on CORS
         // given
         val anthropic = Anthropic {
             baseUrl = env["MOONSHOT_API_BASE_URL"]


### PR DESCRIPTION
## Summary
- Skip `MoonshotTest` on browser targets (`jsBrowser`, `wasmJsBrowser`); Node targets continue to exercise the endpoint.
- The test Moonshot API server's nginx returns `401` with no CORS headers on `OPTIONS /v1/messages`, so browsers block the actual POST with `Failed to fetch`. Reproduced locally and on CI; not a flake. Fix belongs in the upstream nginx CORS config — until then, the guard keeps `jsBrowserTest` green.

## Test plan
- [x] `./gradlew :jsBrowserTest :jsNodeTest :wasmJsBrowserTest :wasmJsNodeTest -PjvmOnlyBuild=false -PrunMoonshotTests=true --tests "com.xemantic.ai.anthropic.MoonshotTest*"` → BUILD SUCCESSFUL (browser entry short-circuits with `time=0.0`, Node targets pass against the real API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)