### PR TITLE
fix: tolerate missing content_block_stop in streaming

### DIFF
--- a/src/commonMain/kotlin/message/MessageStreaming.kt
+++ b/src/commonMain/kotlin/message/MessageStreaming.kt
@@ -34,11 +34,7 @@ suspend fun Flow<Event>.toMessageResponse(): MessageResponse {
     var currentBlock: ContentBlockStart.ContentBlock? = null
     var messageStopped = false
 
-    // Finalizes the open block (if any) into the content list. Used by the
-    // explicit content_block_stop path, and also to synthesize an implicit
-    // stop when a new content_block_start arrives or the stream ends with a
-    // block still open — some Anthropic-compatible providers (e.g. Kimi via
-    // Moonshot's compat layer) omit content_block_stop between blocks.
+    // Flush open block — some providers (e.g. Kimi via Moonshot) omit content_block_stop.
     fun flushCurrent() {
         val block = currentBlock ?: return
         content += when (block) {
@@ -118,6 +114,7 @@ suspend fun Flow<Event>.toMessageResponse(): MessageResponse {
                 )
             }
             is MessageStop -> {
+                flushCurrent()
                 response = response!!.copy(
                     content = content
                 )

--- a/src/commonMain/kotlin/message/MessageStreaming.kt
+++ b/src/commonMain/kotlin/message/MessageStreaming.kt
@@ -16,11 +16,7 @@
 
 package com.xemantic.ai.anthropic.message
 
-import com.xemantic.ai.anthropic.content.Content
-import com.xemantic.ai.anthropic.content.RedactedThinkingBlock
-import com.xemantic.ai.anthropic.content.Text
-import com.xemantic.ai.anthropic.content.ThinkingBlock
-import com.xemantic.ai.anthropic.content.ToolUse
+import com.xemantic.ai.anthropic.content.*
 import com.xemantic.ai.anthropic.error.AnthropicApiException
 import com.xemantic.ai.anthropic.event.Event
 import com.xemantic.ai.anthropic.event.Event.*
@@ -37,12 +33,41 @@ suspend fun Flow<Event>.toMessageResponse(): MessageResponse {
     val content = mutableListOf<Content>()
     var currentBlock: ContentBlockStart.ContentBlock? = null
     var messageStopped = false
+
+    // Finalizes the open block (if any) into the content list. Used by the
+    // explicit content_block_stop path, and also to synthesize an implicit
+    // stop when a new content_block_start arrives or the stream ends with a
+    // block still open — some Anthropic-compatible providers (e.g. Kimi via
+    // Moonshot's compat layer) omit content_block_stop between blocks.
+    fun flushCurrent() {
+        val block = currentBlock ?: return
+        content += when (block) {
+            is ContentBlockStart.ContentBlock.Text -> Text(builder.toString())
+            is ContentBlockStart.ContentBlock.ToolUse -> ToolUse {
+                id = block.id
+                name = block.name
+                input = Json.decodeFromString<JsonObject>(builder.toString())
+            }
+            is ContentBlockStart.ContentBlock.Thinking -> ThinkingBlock {
+                thinking = builder.toString()
+                signature = signatureBuilder.toString().ifEmpty { null }
+            }
+            is ContentBlockStart.ContentBlock.RedactedThinking -> RedactedThinkingBlock {
+                data = block.data
+            }
+        }
+        builder.clear()
+        signatureBuilder.clear()
+        currentBlock = null
+    }
+
     collect { event ->
         when (event) {
             is MessageStart -> {
                 response = event.message
             }
             is ContentBlockStart -> {
+                flushCurrent()
                 currentBlock = event.contentBlock
                 when (val block = event.contentBlock) {
                     is ContentBlockStart.ContentBlock.Text -> {
@@ -66,25 +91,10 @@ suspend fun Flow<Event>.toMessageResponse(): MessageResponse {
                 }
             }
             is ContentBlockStop -> {
-                content += when (val block = currentBlock) {
-                    is ContentBlockStart.ContentBlock.Text -> Text(builder.toString())
-                    is ContentBlockStart.ContentBlock.ToolUse -> ToolUse {
-                        id = block.id
-                        name = block.name
-                        input = Json.decodeFromString<JsonObject>(builder.toString())
-                    }
-                    is ContentBlockStart.ContentBlock.Thinking -> ThinkingBlock {
-                        thinking = builder.toString()
-                        signature = signatureBuilder.toString().ifEmpty { null }
-                    }
-                    is ContentBlockStart.ContentBlock.RedactedThinking -> RedactedThinkingBlock {
-                        data = block.data
-                    }
-                    null -> error("content_block_stop received without a preceding content_block_start")
+                check(currentBlock != null) {
+                    "content_block_stop received without a preceding content_block_start"
                 }
-                builder.clear()
-                signatureBuilder.clear()
-                currentBlock = null
+                flushCurrent()
             }
             is MessageDelta -> {
                 val startUsage = response!!.usage

--- a/src/commonTest/kotlin/MoonshotTest.kt
+++ b/src/commonTest/kotlin/MoonshotTest.kt
@@ -17,30 +17,48 @@
 package com.xemantic.ai.anthropic
 
 import com.xemantic.ai.anthropic.content.Text
-import com.xemantic.ai.anthropic.message.Role
-import com.xemantic.ai.anthropic.message.StopReason
+import com.xemantic.ai.anthropic.content.ThinkingBlock
+import com.xemantic.ai.anthropic.content.ToolUse
+import com.xemantic.ai.anthropic.message.Message
+import com.xemantic.ai.anthropic.message.plusAssign
+import com.xemantic.ai.anthropic.message.toMessageResponse
 import com.xemantic.ai.anthropic.test.env
 import com.xemantic.ai.anthropic.thinking.ThinkingConfig
+import com.xemantic.ai.anthropic.tool.Toolbox
+import com.xemantic.ai.tool.schema.meta.Description
 import com.xemantic.kotlin.test.be
 import com.xemantic.kotlin.test.have
 import com.xemantic.kotlin.test.isBrowserPlatform
 import com.xemantic.kotlin.test.should
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerialName
 import kotlin.test.Test
 
 class MoonshotTest {
+
+    private fun moonshotAnthropic(
+        block: Anthropic.Config.() -> Unit = {}
+    ) = Anthropic {
+        baseUrl = env["MOONSHOT_API_BASE_URL"]
+        defaultModel = env["MOONSHOT_DEFAULT_MODEL"]
+        apiKey = env["MOONSHOT_API_KEY"]
+        useXApiKeyHeader = false
+        useAuthorizationBearerHeader = true
+        block()
+    }
+
+    @SerialName("get_weather")
+    @Description("Get the current weather in a given location")
+    class GetWeather(
+        @Description("The city and state, e.g. San Francisco, CA")
+        val location: String
+    )
 
     @Test
     fun `should receive an introduction from Kimi`() = runTest {
         if (isBrowserPlatform) return@runTest // our test Moonshot API server depends on CORS
         // given
-        val anthropic = Anthropic {
-            baseUrl = env["MOONSHOT_API_BASE_URL"]
-            defaultModel = env["MOONSHOT_DEFAULT_MODEL"]
-            apiKey = env["MOONSHOT_API_KEY"]
-            useXApiKeyHeader = false
-            useAuthorizationBearerHeader = true
-        }
+        val anthropic = moonshotAnthropic()
 
         // when
         val response = anthropic.messages.create {
@@ -50,9 +68,9 @@ class MoonshotTest {
 
         // then
         response should {
-            have(role == Role.ASSISTANT)
+            have(role == ASSISTANT)
             have("Kimi" in model)
-            have(stopReason == StopReason.END_TURN)
+            have(stopReason == END_TURN)
             have(content.size == 1)
             content[0] should {
                 be<Text>()
@@ -62,6 +80,65 @@ class MoonshotTest {
             usage should {
                 have(inputTokens > 0)
                 have(outputTokens > 0)
+            }
+        }
+    }
+
+    @Test
+    fun `should stream an introduction from Kimi with adaptive thinking`() = runTest {
+        if (isBrowserPlatform) return@runTest // our test Moonshot API server depends on CORS
+        // given
+        val anthropic = moonshotAnthropic()
+
+        // when
+        val response = anthropic.messages.stream {
+            +"Hello World! What's your name?"
+            thinking = ThinkingConfig.Adaptive()
+        }.toMessageResponse()
+
+        // then
+        response should {
+            have(role == ASSISTANT)
+            have("Kimi" in model)
+            have(stopReason == END_TURN)
+            content[0] should {
+                be<ThinkingBlock>()
+            }
+            content[1] should {
+                be<Text>()
+                have("Kimi" in text)
+            }
+        }
+    }
+
+    @Test
+    fun `should stream tool use from Kimi`() = runTest {
+        if (isBrowserPlatform) return@runTest // our test Moonshot API server depends on CORS
+        // given
+        val toolbox = Toolbox {
+            tool<GetWeather> {
+                "15 degrees in $location"
+            }
+        }
+        val anthropic = moonshotAnthropic {
+            defaultTools = toolbox.tools
+        }
+        val conversation = mutableListOf<Message>()
+        conversation += "What is the weather like in San Francisco?"
+
+        // when
+        val response = anthropic.messages.stream {
+            messages = conversation
+            thinking = ThinkingConfig.Disabled
+        }.toMessageResponse()
+
+        // then
+        response should {
+            have(stopReason == TOOL_USE)
+            have(content.any { it is ToolUse })
+            content.filterIsInstance<ToolUse>().first() should {
+                have(name == "get_weather")
+                have("San Francisco" in (input["location"]?.toString() ?: ""))
             }
         }
     }

--- a/src/commonTest/kotlin/ResponseStreamingTest.kt
+++ b/src/commonTest/kotlin/ResponseStreamingTest.kt
@@ -16,8 +16,11 @@
 
 package com.xemantic.ai.anthropic
 
+import com.xemantic.ai.anthropic.content.Text
+import com.xemantic.ai.anthropic.content.ToolUse
 import com.xemantic.ai.anthropic.error.AnthropicApiException
 import com.xemantic.ai.anthropic.event.Event
+import com.xemantic.ai.anthropic.json.anthropicJson
 import com.xemantic.ai.anthropic.message.Message
 import com.xemantic.ai.anthropic.message.addCacheBreakpoint
 import com.xemantic.ai.anthropic.message.plusAssign
@@ -103,6 +106,144 @@ class ResponseStreamingTest {
                     have(ephemeral5mInputTokens!! == cacheCreationInputTokens)
                     have(ephemeral1hInputTokens!! == 0)
                 }
+            }
+        }
+    }
+
+    @Test
+    fun `should tolerate missing intermediate content_block_stop`() = runTest {
+        // given
+        // Synthetic event sequence simulating an Anthropic-compatible provider
+        // (e.g. Kimi via Moonshot) that omits content_block_stop between blocks.
+        val events = listOf(
+            """
+                {
+                  "type": "message_start",
+                  "message": {
+                    "type": "message",
+                    "id": "msg_test",
+                    "model": "claude-haiku-4-5",
+                    "role": "assistant",
+                    "content": [],
+                    "stop_reason": null,
+                    "stop_sequence": null,
+                    "usage": {"input_tokens": 10, "output_tokens": 1}
+                  }
+                }
+            """,
+            """
+                {
+                  "type": "content_block_start",
+                  "index": 0,
+                  "content_block": {"type": "text", "text": ""}
+                }
+            """,
+            """
+                {
+                  "type": "content_block_delta",
+                  "index": 0,
+                  "delta": {"type": "text_delta", "text": "Hello"}
+                }
+            """,
+            """
+                {
+                  "type": "content_block_start",
+                  "index": 1,
+                  "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "calc",
+                    "input": {}
+                  }
+                }
+            """,
+            """
+                {
+                  "type": "content_block_delta",
+                  "index": 1,
+                  "delta": {"type": "input_json_delta", "partial_json": "{\"x\":1}"}
+                }
+            """,
+            """{"type": "content_block_stop", "index": 1}""",
+            """
+                {
+                  "type": "message_delta",
+                  "delta": {"stop_reason": "tool_use", "stop_sequence": null},
+                  "usage": {"output_tokens": 5}
+                }
+            """,
+            """{"type": "message_stop"}"""
+        ).map { anthropicJson.decodeFromString<Event>(it) }
+
+        // when
+        val response = events.asFlow().toMessageResponse()
+
+        // then
+        response.content should {
+            have(size == 2)
+            filterIsInstance<Text>().first() should {
+                have(text == "Hello")
+            }
+            filterIsInstance<ToolUse>().first() should {
+                have(name == "calc")
+                have(id == "toolu_1")
+            }
+        }
+    }
+
+    @Test
+    fun `should tolerate missing final content_block_stop`() = runTest {
+        // given
+        // Synthetic event sequence simulating a provider that omits the final
+        // content_block_stop before message_stop.
+        val events = listOf(
+            """
+                {
+                  "type": "message_start",
+                  "message": {
+                    "type": "message",
+                    "id": "msg_test",
+                    "model": "claude-haiku-4-5",
+                    "role": "assistant",
+                    "content": [],
+                    "stop_reason": null,
+                    "stop_sequence": null,
+                    "usage": {"input_tokens": 10, "output_tokens": 1}
+                  }
+                }
+            """,
+            """
+                {
+                  "type": "content_block_start",
+                  "index": 0,
+                  "content_block": {"type": "text", "text": ""}
+                }
+            """,
+            """
+                {
+                  "type": "content_block_delta",
+                  "index": 0,
+                  "delta": {"type": "text_delta", "text": "Hello"}
+                }
+            """,
+            """
+                {
+                  "type": "message_delta",
+                  "delta": {"stop_reason": "end_turn", "stop_sequence": null},
+                  "usage": {"output_tokens": 5}
+                }
+            """,
+            """{"type": "message_stop"}"""
+        ).map { anthropicJson.decodeFromString<Event>(it) }
+
+        // when
+        val response = events.asFlow().toMessageResponse()
+
+        // then
+        response.content should {
+            have(size == 1)
+            filterIsInstance<Text>().first() should {
+                have(text == "Hello")
             }
         }
     }


### PR DESCRIPTION
## Summary
- Some Anthropic-compatible providers (e.g. Kimi via Moonshot's compat layer) omit `content_block_stop` between blocks, which previously caused the streaming parser to drop or mis-attribute content.
- Refactored block finalization into a `flushCurrent()` helper and call it implicitly on each `content_block_start` (and at stream end via the existing flow), so an unterminated open block is closed before a new one starts.
- `content_block_stop` still asserts a preceding `content_block_start` and delegates to the same helper — behavior on well-formed streams is unchanged.

## Test plan
- [ ] Run the existing streaming tests against Anthropic (well-formed `content_block_stop` path).
- [ ] Run `MoonshotTest` (Kimi) end-to-end and confirm streamed tool-use and text blocks are parsed correctly without explicit `content_block_stop` events.
- [ ] Sanity-check thinking + redacted-thinking streaming still produce the expected blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)