### PR TITLE
feat: Claude Opus 4.8 model and effort support via output_config

### DIFF
--- a/src/commonMain/kotlin/Anthropic.kt
+++ b/src/commonMain/kotlin/Anthropic.kt
@@ -145,6 +145,7 @@ class Anthropic internal constructor(
 
     enum class Beta(val id: String) {
         OUTPUT_128K_2025_02_19("output-128k-2025-02-19"),
+        OUTPUT_300K_2026_03_24("output-300k-2026-03-24"),
         COMPUTER_USE_2025_01_24("computer-use-2025-01-24"),
         COMPUTER_USE_2024_10_22("computer-use-2024-10-22"),
         WEB_SEARCH_2025_03_05("web-search-2025-03-05"),

--- a/src/commonMain/kotlin/Models.kt
+++ b/src/commonMain/kotlin/Models.kt
@@ -44,6 +44,18 @@ data class Model(
 
     companion object {
 
+        val CLAUDE_OPUS_4_8 = Model(
+            id = "claude-opus-4-8",
+            contextWindow = 1000000,
+            maxOutput = 128000,
+            messageBatchesApi = true,
+            cost = Cost {
+                inputTokens = "5".dollarsPerMillion
+                outputTokens = "25".dollarsPerMillion
+            },
+            cacheMinTokens = 1024
+        )
+
         val CLAUDE_OPUS_4_7 = Model(
             id = "claude-opus-4-7",
             contextWindow = 1000000,
@@ -53,7 +65,7 @@ data class Model(
                 inputTokens = "5".dollarsPerMillion
                 outputTokens = "25".dollarsPerMillion
             },
-            cacheMinTokens = 1024
+            cacheMinTokens = 2048
         )
 
         val CLAUDE_SONNET_4_6 = Model(
@@ -89,7 +101,7 @@ data class Model(
                 inputTokens = "5".dollarsPerMillion
                 outputTokens = "25".dollarsPerMillion
             },
-            cacheMinTokens = 1024
+            cacheMinTokens = 4096
         )
 
         val CLAUDE_OPUS_4_5_20251101 = Model(
@@ -101,7 +113,7 @@ data class Model(
                 inputTokens = "5".dollarsPerMillion
                 outputTokens = "25".dollarsPerMillion
             },
-            cacheMinTokens = 1024
+            cacheMinTokens = 4096
         )
 
         val CLAUDE_OPUS_4_1_20250805 = Model(
@@ -125,6 +137,7 @@ data class Model(
                 inputTokens = "15".dollarsPerMillion
                 outputTokens = "75".dollarsPerMillion
             },
+            deprecated = true,
             cacheMinTokens = 1024
         )
 
@@ -137,6 +150,7 @@ data class Model(
                 inputTokens = "3".dollarsPerMillion
                 outputTokens = "15".dollarsPerMillion
             },
+            deprecated = true,
             cacheMinTokens = 1024
         )
 
@@ -149,6 +163,7 @@ data class Model(
                 inputTokens = "3".dollarsPerMillion
                 outputTokens = "15".dollarsPerMillion
             },
+            deprecated = true,
             cacheMinTokens = 1024
         )
 
@@ -225,6 +240,7 @@ data class Model(
                 inputTokens = "0.25".dollarsPerMillion
                 outputTokens = "1.25".dollarsPerMillion
             },
+            deprecated = true,
             cacheMinTokens = 2048
         )
 

--- a/src/commonMain/kotlin/message/Messages.kt
+++ b/src/commonMain/kotlin/message/Messages.kt
@@ -25,6 +25,7 @@ import com.xemantic.ai.anthropic.content.Text
 import com.xemantic.ai.anthropic.content.ToolUse
 import com.xemantic.ai.anthropic.json.anthropicJson
 import com.xemantic.ai.anthropic.json.toPrettyJson
+import com.xemantic.ai.anthropic.output.OutputConfig
 import com.xemantic.ai.anthropic.thinking.ThinkingConfig
 import com.xemantic.ai.anthropic.tool.Tool
 import com.xemantic.ai.anthropic.tool.ToolChoice
@@ -76,7 +77,9 @@ data class MessageRequest(
     val topK: Int?,
     @SerialName("top_p")
     val topP: Double?,
-    val thinking: ThinkingConfig?
+    val thinking: ThinkingConfig?,
+    @SerialName("output_config")
+    val outputConfig: OutputConfig?
 ) {
 
     class Builder {
@@ -94,6 +97,15 @@ data class MessageRequest(
         var topK: Int? = null
         var topP: Double? = null
         var thinking: ThinkingConfig? = null
+
+        /**
+         * Controls how Claude produces output for this request, serialized as
+         * the `output_config` field — most notably the reasoning/output effort
+         * level. Assign a prebuilt [OutputConfig], or use the
+         * `outputConfig { … }` builder function below. See [OutputConfig] and
+         * [OutputConfig.effort] for per-model availability.
+         */
+        var outputConfig: OutputConfig? = null
 
         fun messages(vararg messages: Message) {
             this.messages += messages.toList()
@@ -128,6 +140,18 @@ data class MessageRequest(
             maxTokens = model.maxOutput
         }
 
+        /**
+         * Builds an [OutputConfig] from [block] and assigns it, enabling the
+         * idiomatic `outputConfig { effort = Effort.XHIGH }` form.
+         */
+        @OptIn(ExperimentalContracts::class)
+        fun outputConfig(block: OutputConfig.Builder.() -> Unit) {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            outputConfig = OutputConfig(block)
+        }
+
         fun build(): MessageRequest = MessageRequest(
             model = requireNotNull(model) { "model must be specified" },
             maxTokens = requireNotNull(maxTokens) { "maxTokens must be specified" },
@@ -141,7 +165,8 @@ data class MessageRequest(
             tools = tools.ifEmpty { null },
             topK = topK,
             topP = topP,
-            thinking = thinking
+            thinking = thinking,
+            outputConfig = outputConfig
         )
 
     }

--- a/src/commonMain/kotlin/output/OutputConfig.kt
+++ b/src/commonMain/kotlin/output/OutputConfig.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Xemantic contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.ai.anthropic.output
+
+import com.xemantic.ai.anthropic.json.toPrettyJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * Controls how much effort Claude spends generating a response.
+ *
+ * Effort is a soft behavioral signal — not a hard token budget — that
+ * influences all output tokens: text, tool calls, and extended thinking.
+ * Higher effort favors quality and thoroughness; lower effort favors speed
+ * and lower token usage. The hard ceiling on total output always remains
+ * `max_tokens`. Setting effort to [HIGH] produces exactly the same behavior
+ * as omitting it.
+ *
+ * Availability is model-dependent:
+ * - [XHIGH] is supported only on Claude Opus 4.8 and Claude Opus 4.7.
+ * - [MAX] is supported on Claude Opus 4.8 / 4.7 / 4.6, Claude Sonnet 4.6 and
+ *   Claude Mythos Preview, but not on Claude Opus 4.5.
+ *
+ * Requesting an effort level the target model does not support results in an
+ * API error.
+ */
+@Serializable
+enum class Effort {
+
+    @SerialName("low")
+    LOW,
+
+    @SerialName("medium")
+    MEDIUM,
+
+    @SerialName("high")
+    HIGH,
+
+    @SerialName("xhigh")
+    XHIGH,
+
+    @SerialName("max")
+    MAX
+
+}
+
+/**
+ * Configuration controlling how Claude produces output, serialized as the
+ * `output_config` field of a message request.
+ *
+ * @property effort The [Effort] level Claude should apply, or `null` to use
+ *   the API default (equivalent to [Effort.HIGH]).
+ */
+@Serializable
+data class OutputConfig(
+    val effort: Effort? = null
+) {
+
+    class Builder {
+        var effort: Effort? = null
+
+        fun build(): OutputConfig = OutputConfig(
+            effort = effort
+        )
+    }
+
+    companion object {
+
+        @OptIn(ExperimentalContracts::class)
+        operator fun invoke(block: Builder.() -> Unit): OutputConfig {
+            contract {
+                callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+            }
+            return Builder().apply(block).build()
+        }
+
+    }
+
+    override fun toString(): String = toPrettyJson()
+
+}

--- a/src/commonMain/kotlin/output/OutputConfig.kt
+++ b/src/commonMain/kotlin/output/OutputConfig.kt
@@ -65,6 +65,10 @@ enum class Effort {
  * Configuration controlling how Claude produces output, serialized as the
  * `output_config` field of a message request.
  *
+ * Note: an `OutputConfig` with no properties set serializes as an empty
+ * `"output_config": {}` object, which the API treats the same as omitting
+ * the field — leave `outputConfig` unset on the request instead.
+ *
  * @property effort The [Effort] level Claude should apply, or `null` to use
  *   the API default (equivalent to [Effort.HIGH]).
  */

--- a/src/commonMain/kotlin/thinking/ThinkingConfig.kt
+++ b/src/commonMain/kotlin/thinking/ThinkingConfig.kt
@@ -50,7 +50,7 @@ sealed class ThinkingConfig {
         /**
          * Thinking blocks are returned with an empty `thinking` field, but the
          * `signature` is still provided for multi-turn continuity. Default on
-         * Claude Opus 4.7 and Claude Mythos Preview.
+         * Claude Opus 4.7, Claude Opus 4.8 and Claude Mythos Preview.
          */
         @SerialName("omitted")
         OMITTED
@@ -61,13 +61,14 @@ sealed class ThinkingConfig {
      * Extended thinking enabled with a specified token budget.
      *
      * Note: Deprecated on Claude Opus 4.6 and Claude Sonnet 4.6, and not
-     * supported on Claude Opus 4.7 — use [Adaptive] on those models.
+     * supported on Claude Opus 4.7 or Claude Opus 4.8 — use [Adaptive] on
+     * those models.
      *
      * @property budgetTokens Determines how many tokens Claude can use for its
      *   internal reasoning process. Must be ≥1024 and less than max_tokens.
      * @property display Whether to return summarized thinking text or only the
      *   signature. Defaults to [ThinkingConfig.Display.SUMMARIZED] on Claude 4 models
-     *   and [ThinkingConfig.Display.OMITTED] on Claude Opus 4.7 / Mythos Preview.
+     *   and [ThinkingConfig.Display.OMITTED] on Claude Opus 4.7 / 4.8 / Mythos Preview.
      */
     @Serializable
     @SerialName("enabled")
@@ -102,7 +103,7 @@ sealed class ThinkingConfig {
 
     /**
      * Adaptive extended thinking. Claude decides whether and how much to think
-     * based on the prompt. Recommended on Claude Opus 4.6 / 4.7 and Claude
+     * based on the prompt. Recommended on Claude Opus 4.6 / 4.7 / 4.8 and Claude
      * Sonnet 4.6, and the default on Claude Mythos Preview.
      *
      * @property display Whether to return summarized thinking text or only the

--- a/src/commonTest/kotlin/message/MessageRequestTest.kt
+++ b/src/commonTest/kotlin/message/MessageRequestTest.kt
@@ -19,6 +19,8 @@ package com.xemantic.ai.anthropic.message
 import com.xemantic.ai.anthropic.Model
 import com.xemantic.ai.anthropic.content.Text
 import com.xemantic.ai.anthropic.json.anthropicJson
+import com.xemantic.ai.anthropic.output.Effort
+import com.xemantic.ai.anthropic.output.OutputConfig
 import com.xemantic.ai.anthropic.tool.*
 import com.xemantic.ai.tool.schema.meta.Description
 import com.xemantic.kotlin.test.sameAsJson
@@ -417,6 +419,106 @@ class MessageRequestTest {
         json sameAsJson """
             {
               "model": "claude-opus-4-6",
+              "messages": [
+                {
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": "Hey Claude!?"
+                    }
+                  ]
+                }
+              ],
+              "max_tokens": 128000
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should serialize effort as output_config`() {
+        // given
+        val request = MessageRequest(model = Model.CLAUDE_OPUS_4_8) {
+            outputConfig { effort = Effort.XHIGH }
+            +"Hey Claude!?"
+        }
+
+        // when
+        val json = anthropicJson.encodeToString(request)
+
+        // then
+        json sameAsJson """
+            {
+              "model": "claude-opus-4-8",
+              "messages": [
+                {
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": "Hey Claude!?"
+                    }
+                  ]
+                }
+              ],
+              "max_tokens": 128000,
+              "output_config": {
+                "effort": "xhigh"
+              }
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should serialize effort as output_config when assigned as property`() {
+        // given
+        val request = MessageRequest(model = Model.CLAUDE_OPUS_4_8) {
+            outputConfig = OutputConfig {
+                effort = Effort.XHIGH
+            }
+            +"Hey Claude!?"
+        }
+
+        // when
+        val json = anthropicJson.encodeToString(request)
+
+        // then
+        json sameAsJson """
+            {
+              "model": "claude-opus-4-8",
+              "messages": [
+                {
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": "Hey Claude!?"
+                    }
+                  ]
+                }
+              ],
+              "max_tokens": 128000,
+              "output_config": {
+                "effort": "xhigh"
+              }
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should not serialize output_config when it is not set`() {
+        // given
+        val request = MessageRequest(model = Model.CLAUDE_OPUS_4_8) {
+            +"Hey Claude!?"
+        }
+
+        // when
+        val json = anthropicJson.encodeToString(request)
+
+        // then
+        json sameAsJson """
+            {
+              "model": "claude-opus-4-8",
               "messages": [
                 {
                   "role": "user",

--- a/src/commonTest/kotlin/message/MessageRequestTest.kt
+++ b/src/commonTest/kotlin/message/MessageRequestTest.kt
@@ -438,6 +438,8 @@ class MessageRequestTest {
     @Test
     fun `should serialize effort as output_config`() {
         // given
+        // the DSL form of setting outputConfig, the next test verifies
+        // direct property assignment producing the same JSON
         val request = MessageRequest(model = Model.CLAUDE_OPUS_4_8) {
             outputConfig { effort = Effort.XHIGH }
             +"Hey Claude!?"
@@ -472,6 +474,8 @@ class MessageRequestTest {
     @Test
     fun `should serialize effort as output_config when assigned as property`() {
         // given
+        // the property assignment form of setting outputConfig, expected JSON
+        // is identical to the DSL form verified by the previous test
         val request = MessageRequest(model = Model.CLAUDE_OPUS_4_8) {
             outputConfig = OutputConfig {
                 effort = Effort.XHIGH


### PR DESCRIPTION
## Summary

- Add the `CLAUDE_OPUS_4_8` model (1M context window, 128K max output, $5/$25 per MTok, batches support, 1024-token cache minimum)
- Add `OutputConfig` with the `Effort` enum (`low` / `medium` / `high` / `xhigh` / `max`), serialized as the `output_config` field of a message request, with both property assignment and the `outputConfig { effort = … }` builder form
- Add the `OUTPUT_300K_2026_03_24` beta header (raises `max_tokens` to 300K on the Message Batches API for Opus 4.6 / Sonnet 4.6)
- Mark Opus 4, Sonnet 4, Sonnet 3.7 and Haiku 3 as `deprecated`
- Correct `cacheMinTokens` per current prompt-caching docs: Opus 4.7 → 2048, Opus 4.6 and 4.5 → 4096
- Extend `ThinkingConfig` docs to cover Claude Opus 4.8

## Test plan

- [x] New serialization tests in `MessageRequestTest`: effort via builder, effort via property assignment, and `output_config` omitted when unset
- [x] `./gradlew jvmTest --tests '*MessageRequestTest*' -PjvmOnlyBuild=true` passes

Model facts (pricing, context window, max output, effort level availability, cache minimums, beta header) verified against the current Anthropic API documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)