### PR TITLE
feat: add Claude Sonnet 5 and Claude Fable 5 models

### DIFF
--- a/src/commonMain/kotlin/Models.kt
+++ b/src/commonMain/kotlin/Models.kt
@@ -44,6 +44,18 @@ data class Model(
 
     companion object {
 
+        val CLAUDE_FABLE_5 = Model(
+            id = "claude-fable-5",
+            contextWindow = 1000000,
+            maxOutput = 128000,
+            messageBatchesApi = true,
+            cost = Cost {
+                inputTokens = "10".dollarsPerMillion
+                outputTokens = "50".dollarsPerMillion
+            },
+            cacheMinTokens = 512
+        )
+
         val CLAUDE_OPUS_4_8 = Model(
             id = "claude-opus-4-8",
             contextWindow = 1000000,
@@ -66,6 +78,20 @@ data class Model(
                 outputTokens = "25".dollarsPerMillion
             },
             cacheMinTokens = 2048
+        )
+
+        val CLAUDE_SONNET_5 = Model(
+            id = "claude-sonnet-5",
+            contextWindow = 1000000,
+            maxOutput = 128000,
+            messageBatchesApi = true,
+            // Standard pricing; introductory pricing of $2/$10 per MTok
+            // applies through 2026-08-31.
+            cost = Cost {
+                inputTokens = "3".dollarsPerMillion
+                outputTokens = "15".dollarsPerMillion
+            },
+            cacheMinTokens = 1024
         )
 
         val CLAUDE_SONNET_4_6 = Model(


### PR DESCRIPTION
## Summary

Add the two most recent generally-available Anthropic models to the `Model` enum:

- **`CLAUDE_FABLE_5`** (`claude-fable-5`) — most capable widely released model, 1M context, 128K max output, $10/$50 per MTok, min cacheable prefix 512.
- **`CLAUDE_SONNET_5`** (`claude-sonnet-5`) — 1M context, 128K max output, $3/$15 per MTok standard pricing (introductory $2/$10 through 2026-08-31), min cacheable prefix 1024.

## Notes

- Specs and pricing verified against platform.claude.com models overview, pricing, and prompt-caching docs.
- `Model.DEFAULT` is left unchanged (`CLAUDE_SONNET_4_6`).
- Claude Mythos 5 is omitted as it is invitation-only (Project Glasswing), not generally available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
