### PR TITLE
feat: add missing message stop reasons and stop_details

### DIFF
--- a/src/commonMain/kotlin/message/Messages.kt
+++ b/src/commonMain/kotlin/message/Messages.kt
@@ -271,7 +271,54 @@ enum class StopReason {
     STOP_SEQUENCE,
 
     @SerialName("tool_use")
-    TOOL_USE
+    TOOL_USE,
+
+    /**
+     * The model paused a long-running server-tool turn and can be resumed by
+     * re-sending the conversation. Emitted during agentic flows that use
+     * server-side tools (e.g. web search).
+     */
+    @SerialName("pause_turn")
+    PAUSE_TURN,
+
+    /**
+     * The model declined to generate a response for safety reasons. When this
+     * is the [StopReason], [MessageResponse.stopDetails] is populated with the
+     * refusal [StopDetails.category] and [StopDetails.explanation].
+     */
+    @SerialName("refusal")
+    REFUSAL,
+
+    /**
+     * Generation stopped because the conversation reached the model's context
+     * window limit. Distinct from [MAX_TOKENS], which is the requested output
+     * cap — this signals the input plus output exceeded the context window.
+     */
+    @SerialName("model_context_window_exceeded")
+    MODEL_CONTEXT_WINDOW_EXCEEDED
+}
+
+/**
+ * Structured details accompanying a [StopReason]. Currently populated only
+ * when [MessageResponse.stopReason] is [StopReason.REFUSAL]; it is `null` for
+ * every other stop reason, so always guard on [MessageResponse.stopReason]
+ * before reading these fields.
+ *
+ * @property type The kind of stop detail, e.g. `"refusal"`.
+ * @property category The policy category that triggered the refusal (e.g.
+ *   `"cyber"`, `"bio"`), or `null` when no category is provided.
+ * @property explanation A human-readable explanation of the refusal, when
+ *   available.
+ */
+@Serializable
+data class StopDetails(
+    val type: String,
+    val category: String? = null,
+    val explanation: String? = null
+) {
+
+    override fun toString(): String = toPrettyJson()
+
 }
 
 operator fun MutableCollection<in Message>.plusAssign(
@@ -297,7 +344,9 @@ data class MessageResponse(
     val stopReason: StopReason?,
     @SerialName("stop_sequence")
     val stopSequence: String?,
-    val usage: Usage
+    val usage: Usage,
+    @SerialName("stop_details")
+    val stopDetails: StopDetails? = null
 ) : Response(type = "message") {
 
     fun asMessage(): Message = Message {

--- a/src/commonTest/kotlin/AnthropicTest.kt
+++ b/src/commonTest/kotlin/AnthropicTest.kt
@@ -70,6 +70,48 @@ class AnthropicTest {
     }
 
     @Test
+    fun `should receive no stopDetails for a normal end_turn response`() = runTest {
+        // Note: the newer stop reasons (refusal, pause_turn,
+        // model_context_window_exceeded) cannot be triggered reliably or
+        // safely in a live test, so this verifies that the new stop_details
+        // field deserializes correctly against real API responses and stays
+        // null for an ordinary completion. Enum-value and stop_details parsing
+        // are covered exhaustively by MessageResponseTest unit tests.
+
+        // given
+        val anthropic = testAnthropic()
+
+        // when
+        val response = anthropic.messages.create {
+            +"Hello World! What's your name?"
+        }
+
+        // then
+        response should {
+            have(stopReason == StopReason.END_TURN)
+            have(stopDetails == null)
+        }
+    }
+
+    @Test
+    fun `should stop with MAX_TOKENS and no stopDetails when max tokens reached`() = runTest {
+        // given
+        val anthropic = testAnthropic()
+
+        // when
+        val response = anthropic.messages.create {
+            +"Write a long essay about the history of computing."
+            maxTokens = 1
+        }
+
+        // then
+        response should {
+            have(stopReason == StopReason.MAX_TOKENS)
+            have(stopDetails == null)
+        }
+    }
+
+    @Test
     fun `should use topK and temperature`() = runTest {
         // given
         val anthropic = testAnthropic()

--- a/src/commonTest/kotlin/message/MessageResponseTest.kt
+++ b/src/commonTest/kotlin/message/MessageResponseTest.kt
@@ -300,6 +300,199 @@ class MessageResponseTest {
     }
 
     @Test
+    fun `should deserialize pause_turn stop reason`() {
+        // given
+        val jsonResponse = """
+            {
+              "id": "msg_01PauseTurn",
+              "type": "message",
+              "role": "assistant",
+              "model": "claude-sonnet-4-5-20250929",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Let me keep searching."
+                }
+              ],
+              "stop_reason": "pause_turn",
+              "stop_sequence": null,
+              "usage": {
+                "input_tokens": 100,
+                "output_tokens": 20
+              }
+            }
+        """
+
+        // when
+        val response = anthropicJson.decodeFromString<Response>(jsonResponse)
+
+        // then
+        response should {
+            be<MessageResponse>()
+            have(stopReason == StopReason.PAUSE_TURN)
+            have(stopDetails == null)
+        }
+    }
+
+    @Test
+    fun `should deserialize refusal stop reason with stop_details`() {
+        // given
+        val jsonResponse = """
+            {
+              "id": "msg_01Refusal",
+              "type": "message",
+              "role": "assistant",
+              "model": "claude-sonnet-4-5-20250929",
+              "content": [],
+              "stop_reason": "refusal",
+              "stop_sequence": null,
+              "stop_details": {
+                "type": "refusal",
+                "category": "cyber",
+                "explanation": "The request was declined for safety reasons."
+              },
+              "usage": {
+                "input_tokens": 100,
+                "output_tokens": 0
+              }
+            }
+        """
+
+        // when
+        val response = anthropicJson.decodeFromString<Response>(jsonResponse)
+
+        // then
+        response should {
+            be<MessageResponse>()
+            have(stopReason == StopReason.REFUSAL)
+            have(content.isEmpty())
+            stopDetails!! should {
+                have(type == "refusal")
+                have(category == "cyber")
+                have(explanation == "The request was declined for safety reasons.")
+            }
+        }
+    }
+
+    @Test
+    fun `should deserialize refusal stop_details with null category`() {
+        // given
+        val jsonResponse = """
+            {
+              "id": "msg_01RefusalNoCategory",
+              "type": "message",
+              "role": "assistant",
+              "model": "claude-sonnet-4-5-20250929",
+              "content": [],
+              "stop_reason": "refusal",
+              "stop_sequence": null,
+              "stop_details": {
+                "type": "refusal"
+              },
+              "usage": {
+                "input_tokens": 100,
+                "output_tokens": 0
+              }
+            }
+        """
+
+        // when
+        val response = anthropicJson.decodeFromString<Response>(jsonResponse)
+
+        // then
+        response should {
+            be<MessageResponse>()
+            have(stopReason == StopReason.REFUSAL)
+            stopDetails!! should {
+                have(type == "refusal")
+                have(category == null)
+                have(explanation == null)
+            }
+        }
+    }
+
+    @Test
+    fun `should deserialize model_context_window_exceeded stop reason`() {
+        // given
+        val jsonResponse = """
+            {
+              "id": "msg_01ContextExceeded",
+              "type": "message",
+              "role": "assistant",
+              "model": "claude-sonnet-4-5-20250929",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Partial answer"
+                }
+              ],
+              "stop_reason": "model_context_window_exceeded",
+              "stop_sequence": null,
+              "usage": {
+                "input_tokens": 100,
+                "output_tokens": 20
+              }
+            }
+        """
+
+        // when
+        val response = anthropicJson.decodeFromString<Response>(jsonResponse)
+
+        // then
+        response should {
+            be<MessageResponse>()
+            have(stopReason == StopReason.MODEL_CONTEXT_WINDOW_EXCEEDED)
+            have(stopDetails == null)
+        }
+    }
+
+    @Test
+    fun `should serialize refusal MessageResponse with stop_details to JSON via toString`() {
+        // given
+        val response = MessageResponse(
+            model = "claude-sonnet-4-5-20250929",
+            id = "msg_01Refusal",
+            role = Role.ASSISTANT,
+            content = emptyList(),
+            stopReason = StopReason.REFUSAL,
+            stopSequence = null,
+            usage = Usage {
+                inputTokens = 100
+                outputTokens = 0
+            },
+            stopDetails = StopDetails(
+                type = "refusal",
+                category = "cyber",
+                explanation = "The request was declined for safety reasons."
+            )
+        )
+
+        // when
+        val json = response.toString()
+
+        // then
+        json sameAs /* language=json */ """
+            {
+              "type": "message",
+              "model": "claude-sonnet-4-5-20250929",
+              "id": "msg_01Refusal",
+              "role": "assistant",
+              "content": [],
+              "stop_reason": "refusal",
+              "usage": {
+                "input_tokens": 100,
+                "output_tokens": 0
+              },
+              "stop_details": {
+                "type": "refusal",
+                "category": "cyber",
+                "explanation": "The request was declined for safety reasons."
+              }
+            }
+        """.trimIndent()
+    }
+
+    @Test
     fun `should serialize complex MessageResponse with WebFetch content to JSON via toString`() {
         val response = MessageResponse(
             model = "claude-sonnet-4-5-20250929",


### PR DESCRIPTION
## What

Adds the newer `stop_reason` values the Messages API can return that the SDK did not model yet, plus the `stop_details` object:

- `StopReason.PAUSE_TURN` — model paused a long-running server-tool turn (resumable).
- `StopReason.REFUSAL` — model declined for safety reasons.
- `StopReason.MODEL_CONTEXT_WINDOW_EXCEEDED` — input+output hit the context window (distinct from `MAX_TOKENS`).
- `MessageResponse.stopDetails` (`stop_details`) — new `StopDetails(type, category, explanation)` type, populated on a `refusal` and `null` otherwise.

## Why

Before this change, a response carrying any of these stop reasons would **fail to deserialize** into the `StopReason` enum — a latent correctness bug as more requests hit refusals, server-tool pauses, or the context-window limit. `stop_details` also lets callers inspect *why* a refusal happened.

`category` and `explanation` are modeled as nullable `String` for forward-compatibility with new policy categories.

## Tests

**Unit** (`MessageResponseTest`) — deserialize canned API JSON for each new stop reason, the refusal `stop_details` (including a null-category variant), and a serialization round-trip. All pass locally (`jvmTest`).

**Integration** (`AnthropicTest`) — assert `stopDetails` stays `null` for ordinary `end_turn` and `max_tokens` completions, exercising the new field against live responses. The genuinely new reasons (`refusal`, `pause_turn`, `model_context_window_exceeded`) can't be triggered reliably or safely in a live test, so enum/`stop_details` parsing is covered exhaustively by the unit tests instead.

> Note: the live integration tests were not run in this environment (no `ANTHROPIC_API_KEY`); they compile cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)